### PR TITLE
Let CI be started by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
+  # By hand, for when a push event produces no run at all — which is what
+  # happened to two merges to `main` while GitHub's runners were backed up,
+  # leaving nothing to say whether the branch was green.
+  workflow_dispatch:
 
 # A second push to the same branch makes the first run's answer irrelevant, so
 # cancel it rather than pay for both. Never cancels on main: those runs are the


### PR DESCRIPTION
Two merges to `main` (`f87b0a0`, `4af048c`) produced no workflow run at all — GitHub created no push event for either while its runners were backed up, so nothing says whether `main` is green. With no `workflow_dispatch` there was no way to ask for a run either.

Also drops `dev` from the push triggers: it is fully merged into `main` (0 commits ahead, 91 behind) and is being deleted.

This PR's own run doubles as the check on `main`, since it now includes the lockfile repair from #24.