### PR TITLE
fix: hold the toggled node still, and open a branch out of its own parent

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,13 @@
+---
+'@klad/engine': patch
+'@klad/core': patch
+---
+
+Expand/collapse fixes.
+
+- The toggled node now stays where it was clicked for the whole transition: a click, a hand-drift or a drag can no longer walk the camera off, and rapid clicking cannot ratchet it away.
+- A click resolves against what is on screen, not the layout the chart is heading for, so it toggles the card you aimed at mid-animation.
+- Children caught mid-reveal or mid-collapse are carried at the position they were drawn at, instead of jumping to full size or onto their parent's box.
+- Children grow out of the tip below their own parent, at every depth.
+- Siblings pack the same distance apart whichever one has children.
+- The two animation phases overlap more, so an open or close reads as one move (450ms → 390ms).

--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,6 +1,6 @@
 ---
-'@klad/engine': patch
-'@klad/core': patch
+'@klad/engine': minor
+'@klad/core': minor
 ---
 
 Expand/collapse fixes.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4111,9 +4111,13 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
             interpolatedBoxOfSource,
             camera,
             alphaOfSource,
+            // The settled layout, for the size a card is LAID OUT at — see
+            // `OverlayApi.update`. A ghost has left the tree and has no
+            // settled box, so it keeps the one it is fading at.
+            boxOfSource,
           )
         } else {
-          overlay.update([], interpolatedBoxOfSource, camera, alphaOfSource)
+          overlay.update([], interpolatedBoxOfSource, camera, alphaOfSource, boxOfSource)
         }
       }
       publish()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2276,17 +2276,78 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
   }
 
   /**
-   * Hit-test on THIS thread, synchronously.
+   * The interpolated half of `hitTestLocal` — the boxes the canvas actually
+   * painted last frame — or `null` when there is no transition to read them
+   * from and the settled layout is the honest answer.
    *
-   * `chartHost.hitTest` returns a promise — in worker mode it may genuinely
-   * have to ask — and a drag cannot await one: the answer would arrive a frame
-   * or two after the pointer has moved on, so the preview would trail the
-   * cursor and, worse, `onDragStart` would have to decide whether to claim the
-   * gesture before it knew if there was a node under it. Every input this
-   * needs is already mirrored on the main thread for the overlay, so it
-   * answers now.
+   * Bounded work: `drawn` is the culled, on-screen set, and this runs once per
+   * click or per pointer move, never per frame. Last drawn wins, matching the
+   * paint order — mid-transition, boxes really can overlap.
+   */
+  const hitTestDrawn = (worldX: number, worldY: number): number | null => {
+    if (!chartHost.transitioning) return null
+    // `renderBoxBySource`, looked up per drawn node — NOT
+    // `chartHost.lastDrawnBoxes` read positionally. The map and `drawn` are
+    // rebuilt together in the same synchronous block after every awaited
+    // render, so the pair always describes ONE frame. The host's mirror does
+    // not hold that promise between renders: in worker mode every message
+    // provokes a `frame` reply, so a camera or toggle message landing
+    // between this layer's awaited renders refreshes the mirror while
+    // `drawn` stays put. A tap in that window used to pair the previous
+    // frame's `drawn` with a newer frame's boxes — and when a collapse had
+    // just shrunk the drawn set, the positional read ran off the end of the
+    // newer, shorter array, every bounds comparison against `undefined` came
+    // back false, and the "hit" was whichever node happened to sit LAST in
+    // the stale `drawn`. A rapid click then toggled a node nowhere near the
+    // pointer and anchored the camera on it. Ghosts stay unhittable exactly
+    // as before: they are in the map but never in `drawn` — a node on its
+    // way out is not something a click can land on, it is leaving.
+    const drawnBoxes = renderBoxBySource
+    if (drawnBoxes === null) return null
+    for (let i = drawn.length - 1; i >= 0; i--) {
+      const box = drawnBoxes.get(drawn[i]!)
+      if (box === undefined) continue
+      if (worldX < box.x || worldY < box.y) continue
+      if (worldX > box.x + box.w || worldY > box.y + box.h) continue
+      return drawn[i]!
+    }
+    return -1
+  }
+
+  /**
+   * Hit-test on THIS thread, synchronously, against WHAT IS ON THE CANVAS —
+   * the interpolated boxes while a transition is running, and otherwise the
+   * layout of the last frame this layer actually rendered.
+   *
+   * Two reasons it does not simply ask `chartHost.hitTest`, and they are the
+   * same reason twice: that one answers from the layout the chart is heading
+   * FOR, not the one in front of the viewer.
+   *
+   *  - It returns a promise — in worker mode it may genuinely have to ask —
+   *    and a drag cannot await one: the answer would arrive a frame or two
+   *    after the pointer has moved on, so the preview would trail the cursor
+   *    and, worse, `onDragStart` would have to decide whether to claim the
+   *    gesture before it knew if there was a node under it.
+   *  - And it resolves against the FINAL layout, relayouting eagerly if a
+   *    toggle has dirtied one. That is right at rest and wrong for the whole
+   *    of an expand/collapse: the card the viewer is aiming at is at its
+   *    interpolated position, while the box that answers for it is already at
+   *    its destination — a whole screen away on a root toggle. With
+   *    `toggleOnNodeClick` on, a click during the animation therefore toggled
+   *    whatever happened to SETTLE under the point (or nothing), and then
+   *    anchored the camera on that: click a node a dozen times in a row and
+   *    the chart walks off screen. Aiming at what you can see is the whole
+   *    contract of a pointer.
+   *
+   * Every input this needs is already mirrored on the main thread for the
+   * overlay, so it answers now, from the same geometry the overlay is using.
+   * A SUNBURST is the one thing it cannot answer — a wedge is not its bounding
+   * box — and callers there go to `chartHost.hitTest`, which owns the polar
+   * test on both paths.
    */
   const hitTestLocal = (worldX: number, worldY: number): number => {
+    const live = hitTestDrawn(worldX, worldY)
+    if (live !== null) return live
     for (let i = 0; i < visibleToSource.length; i++) {
       const o = i * 4
       const x = boxes[o]!
@@ -3827,7 +3888,29 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
       // after `render()` (its `toCentre` needs the layout that render just
       // produced); at `t = 0` it has nothing to advance yet, so there is no
       // lag to inherit.
-      if (cameraAnchor !== null) applyCameraAnchor(now)
+      // ...and a toggle whose anchor has not been promoted yet holds the node
+      // still in the meantime, which is the other branch inside this call.
+      if (cameraAnchor !== null || pendingAnchor !== null) applyCameraAnchor(now)
+      // The anchor that was armed BEFORE this frame asked for its render —
+      // compared by identity against `pendingAnchor` at the promotion below.
+      //
+      // The render awaited next only reflects toggles that were sent before
+      // it was, so it can only speak for an anchor that was already armed
+      // here. In worker mode that await is a real round trip, and a burst of
+      // fast clicks lands toggles right inside it: each one overwrites
+      // `pendingAnchor` with a toggle whose relayout this frame has NOT
+      // seen. Promoting such an anchor used to build it out of the PREVIOUS
+      // toggle's state — `toCentre` read from a layout the engine had
+      // already abandoned, `startedAt` and the transition direction from a
+      // transition that had already been replaced — and an anchor aimed at a
+      // world point the engine is not heading for walks the camera the whole
+      // distance between the two layouts while the canvas animates somewhere
+      // else. That is up to a layout-width PER RACE HIT, it compounds
+      // because the next promotion re-pins from wherever the drift left the
+      // node, and a dozen fast clicks marched the chart clean off screen.
+      // In-process the await resolves in a microtask, so no click can
+      // interleave and this capture never differs from `pendingAnchor`.
+      const anchorArmedBeforeRender = pendingAnchor
       // The engine's expand/collapse transition is a pure function of time and
       // takes its clock from here, the same discipline `viewport.ts` follows.
       drawn = await chartHost.render(now)
@@ -3894,20 +3977,48 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
         pendingAnchor = null
         cameraAnchor = null
         api.fit()
-      } else if (pendingAnchor !== null) {
+      } else if (pendingAnchor !== null && pendingAnchor === anchorArmedBeforeRender) {
+        // The identity check is the other half of `anchorArmedBeforeRender`'s
+        // docblock: an anchor armed DURING the await is deliberately left in
+        // place for the NEXT frame, whose render is posted after its toggle
+        // and so reports that toggle's layout. That frame is already on its
+        // way — the toggle's own `setOpenFlag` called `scheduleFrame`, and
+        // this callback had cleared `frameRequested` before the toggle
+        // landed, so the request registered a fresh callback rather than
+        // collapsing into this one.
         const anchor = pendingAnchor
         pendingAnchor = null
         // The node's post-relayout box — always present (see `CameraAnchor`'s
         // docblock), but degrade to "no anchor" rather than trust that if it
         // somehow isn't.
         const toBox = boxOfSource(anchor.source)
+        // Where the node is being drawn on THIS frame, which is the frame the
+        // anchor starts holding it from. Normally identical to the pin taken
+        // at the toggle — this runs one frame later, at `t = 0`, before
+        // anything has moved — and then this changes nothing.
+        //
+        // It stops mattering only when the promotion is LATE, and it can be:
+        // this branch sits after `await chartHost.render(now)`, a worker round
+        // trip, and a burst of clicks queues those up behind each other. A
+        // promotion 260ms into a 390ms transition was measured during exactly
+        // the rapid clicking this fix is for. The anchor would then start at
+        // `t = 0.5` against a pin from before any of that travel happened, and
+        // solving the camera for it moved the whole chart by half the node's
+        // journey in a single frame — a hard jump, repeatable, cumulative over
+        // a dozen clicks until the node the viewer started on was off screen.
+        // Pinning where the node IS can never do that: the camera it solves
+        // for on the establishing frame is the camera already in use, whatever
+        // `t` says, and the anchor's job — hold it still FROM HERE — is the
+        // same either way.
+        const liveBox = interpolatedBoxOfSource(anchor.source)
+        const pin = liveBox === null ? null : boxCentre(liveBox)
         cameraAnchor =
           toBox === null
             ? null
             : {
                 source: anchor.source,
-                screenX: anchor.screenX,
-                screenY: anchor.screenY,
+                screenX: pin === null ? anchor.screenX : pin.x * camera.k + camera.x,
+                screenY: pin === null ? anchor.screenY : pin.y * camera.k + camera.y,
                 fromCentre: anchor.fromCentre,
                 toCentre: boxCentre(toBox),
                 opening: anchor.opening,
@@ -4092,7 +4203,28 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
    */
   const applyCameraAnchor = (now: number): void => {
     const anchor = cameraAnchor
-    if (anchor === null) return
+    if (anchor === null) {
+      // The gap between a toggle and the frame that promotes its anchor. It
+      // should be one frame and in worker mode it is a round trip, and until
+      // the relayout lands there is no `toCentre` to interpolate towards — so
+      // this holds the node at the world point it occupied when it was
+      // clicked, which is exactly where the engine is still drawing it: a
+      // collapse does not start closing the gap until a third of the way in,
+      // and an expand has barely moved it. Without this the layout animates
+      // for that gap with nothing holding the node, and the promotion then
+      // takes over from wherever it drifted to — a small jump per toggle, and
+      // rapid clicking is nothing but those gaps back to back. That is the
+      // residual wobble left after the anchor itself stopped being able to
+      // lurch.
+      const pending = pendingAnchor
+      if (pending === null) return
+      applyCamera({
+        x: pending.screenX - pending.fromCentre.x * camera.k,
+        y: pending.screenY - pending.fromCentre.y * camera.k,
+        k: camera.k,
+      })
+      return
+    }
     const stillAnimating = animationsEnabled() && chartHost.transitioning
     const t = stillAnimating ? transitionAnchorProgress(anchor.startedAt, now, anchor.opening) : 1
     const world = lerpPoint(anchor.fromCentre, anchor.toCentre, t)
@@ -4169,9 +4301,12 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
    *    tap anywhere during a root collapse left the root somewhere else
    *    entirely, often off screen.
    *
-   * So a real camera GESTURE (pan, wheel, pinch, or an API move) still drops
-   * the anchor — those all route through `setCameraInstant`/`animateTo`,
-   * which take the default — while a touch that changes no camera does not.
+   * So only an API camera MOVE — `focus`, `fit`, `moveToSource`, a minimap
+   * jump — drops the anchor, through `animateTo` and the one explicit call in
+   * the minimap's `onPan`. A hand gesture (pan, wheel, pinch) does not: it
+   * routes through `setCameraInstant`, which passes `false` here and then
+   * declines to pan at all while the anchor is live — see that function for
+   * why the toggle outranks the gesture for the half-second it lasts.
    */
   const cancelCameraAnimation = (dropToggleAnchor = true): void => {
     if (cameraAnimHandle !== null) {
@@ -4189,9 +4324,47 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
     }
   }
 
-  /** Used by pointer, wheel, and pinch input — see `cancelCameraAnimation`. */
+  /**
+   * True while a single-node expand/collapse owns the camera — either its
+   * anchor is live, or a toggle has armed one and the frame that promotes it
+   * has not run yet (see `pendingAnchor`).
+   */
+  const toggleHoldsCamera = (): boolean => cameraAnchor !== null || pendingAnchor !== null
+
+  /**
+   * Used by pointer, wheel, and pinch input — see `cancelCameraAnimation`.
+   *
+   * For the ~390ms a branch is opening or closing, the node that was toggled
+   * is nailed to the spot it was clicked on and a PAN cannot move it. This is
+   * the owner's rule, and it is the third answer this has had: dropping the
+   * anchor on any gesture abandoned the node mid-move, so the layout carried
+   * the chart off screen; re-pinning the anchor onto the panned camera kept
+   * the node but let every click's worth of hand-drift accumulate, which read
+   * as the camera sliding away a few pixels at a time. Both were versions of
+   * "the user's hand always wins" — right for a settled chart, wrong for the
+   * half-second in which the answer to "where am I looking" is *that node*.
+   * A press during a toggle is overwhelmingly part of the toggling, not a
+   * request to go somewhere else.
+   *
+   * The SCALE still goes through: zoom is not a claim about where the viewer
+   * is looking, only how closely, and the anchor re-solves x/y around the
+   * pinned node on the next frame anyway — so a wheel during a transition
+   * zooms about the node being opened, which is the only sensible reading of
+   * it. x/y are deliberately not applied at all rather than applied and
+   * overwritten a frame later: that would be a visible fight between the pan
+   * and the anchor rather than a chart that holds still.
+   *
+   * Nothing here is permanent. The anchor dies with the transition it rides,
+   * and from that moment the same gesture pans exactly as it always did.
+   */
   const setCameraInstant = (next: Camera): void => {
-    cancelCameraAnimation()
+    // `false`: a gesture no longer drops the toggle anchor — it is the anchor
+    // that outranks the gesture now, not the other way round.
+    cancelCameraAnimation(false)
+    if (toggleHoldsCamera()) {
+      if (next.k !== camera.k) applyCamera({ x: camera.x, y: camera.y, k: next.k })
+      return
+    }
     applyCamera(next)
   }
 
@@ -4260,6 +4433,19 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
     }
     const dt = now - momentumLastT
     momentumLastT = now
+    // A coast is a pan with the hand already off the chart, so it obeys the
+    // same rule `setCameraInstant` does: while a toggle holds the camera, the
+    // toggled node stays where it was clicked and this waits. Dropped, not
+    // deferred — a fling whose whole travel happened while the chart was held
+    // is a fling the viewer never saw start, and releasing it at the end of
+    // the transition would throw the view somewhere they last aimed at half a
+    // second ago.
+    if (toggleHoldsCamera()) {
+      cameraAnimHandle = null
+      momentumVX = 0
+      momentumVY = 0
+      return
+    }
     applyCamera(pan(camera, momentumVX * dt, momentumVY * dt))
     const decay = Math.exp(-dt / MOMENTUM_TAU_MS)
     momentumVX *= decay
@@ -4275,7 +4461,12 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
 
   /** `vx`/`vy` are screen px/ms, as measured by input.ts at pointer release. */
   const startMomentum = (vx: number, vy: number): void => {
-    cancelCameraAnimation()
+    // `false` for the same reason the pan that threw this coast does it (see
+    // `setCameraInstant`): the coast is the tail of that gesture, and a
+    // gesture no longer decides where the camera looks while a toggle is
+    // holding it — `stepMomentum` gives way to the anchor rather than
+    // fighting it.
+    cancelCameraAnimation(false)
     if (!animationsEnabled()) return
     const speed = Math.hypot(vx, vy)
     if (speed < MOMENTUM_MIN_VELOCITY) return
@@ -4321,6 +4512,22 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
           screenY = cameraAnchor.screenY
         }
         pendingAnchor = { source: index, screenX, screenY, fromCentre, opening: value }
+        // The old anchor is DEAD the moment this toggle is sent: the engine
+        // relayouts on it and rebases every node's tween from wherever it is
+        // being drawn right now, onto a new curve with a new clock — so the
+        // curve the old anchor replays no longer describes anything on the
+        // canvas. Letting it keep driving the camera until the promotion
+        // replaces it (which used to happen implicitly, and takes at least a
+        // frame — more in worker mode, where the promotion waits out a real
+        // round trip) moved the camera at the OLD curve's speed, which
+        // mid-transition is its fastest, while the node it claimed to pin sat
+        // still on the new curve's slow start. The node slid off its spot by
+        // that difference and the promotion then re-pinned it WHERE IT SLID
+        // TO, so every rapid re-toggle ratcheted the chart a little further.
+        // A frozen camera is the honest bridge: the new curve leaves it
+        // nearly right (eased curves start at zero velocity), and the
+        // promotion picks the hold up from there.
+        cameraAnchor = null
       }
     }
     open[index] = value ? 1 : 0
@@ -4511,7 +4718,17 @@ export function createKlad(host: HTMLElement, options: Options): KladInstance {
     cancelAnimation: () => cancelCameraAnimation(false),
     onTap(screenX, screenY, target, modifiers) {
       const world = screenToWorld(camera, screenX, screenY)
-      void chartHost.hitTest(world.x, world.y).then((index) => {
+      // The on-screen mirror, not `chartHost.hitTest` — a tap resolves against
+      // what the viewer can see, exactly as a drag does; see `hitTestLocal`
+      // for the whole argument. Only a sunburst, whose wedges no box test can
+      // answer, still asks the engine. The resolved promise keeps the two
+      // paths one piece of code: `.then` on it is a microtask, not a round
+      // trip.
+      const answer =
+        currentOptions.layout === 'sunburst'
+          ? chartHost.hitTest(world.x, world.y)
+          : Promise.resolve(hitTestLocal(world.x, world.y))
+      void answer.then((index) => {
         if (destroyed) return
         if (index === -1) {
           lastTapId = null

--- a/packages/core/src/input.ts
+++ b/packages/core/src/input.ts
@@ -84,9 +84,10 @@ export interface InputCallbacks {
    * A single-pointer drag (not a pinch) just ended. `vx`/`vy` are the release
    * velocity in screen px/ms, estimated from a short rolling window of recent
    * samples — see the `VELOCITY_WINDOW_MS` comment below. Not called for a tap,
-   * and not called when the window's time span is too short to trust (also
-   * below) — the caller (vanilla layer) decides whether to actually start a
-   * momentum coast from this.
+   * not called when the window's time span is too short to trust, and not
+   * called when the gesture never covered enough ground to have been a fling
+   * (both below) — the caller (vanilla layer) decides whether to actually
+   * start a momentum coast from this.
    */
   onRelease(vx: number, vy: number): void
 }
@@ -146,6 +147,13 @@ export function attachInput(
    */
   let claimed = false
   let travelled = 0
+  /**
+   * True once this gesture has actually moved the camera — i.e. it travelled
+   * past `DRAG_THRESHOLD_PX` and nobody claimed it as a node drag. Until then
+   * a press is still a tap and the camera is left alone entirely; see
+   * `onPointerMove`.
+   */
+  let panning = false
   let lastX = 0
   let lastY = 0
   let downX = 0
@@ -180,6 +188,22 @@ export function attachInput(
   // an enormous, meaningless speed. Below the threshold, momentum just isn't
   // started; the drag stops the way it always did.
   const MIN_VELOCITY_SAMPLE_MS = 8
+  // ...and below this much straight-line travel across that same window, the
+  // release is not a fling and starts no coast at all. The time floor alone
+  // cannot tell a fling from a sloppy click, because the two divide out to
+  // the same kind of number: a click made by a hand in motion covers ~6px in
+  // ~10ms, and 0.6px/ms fed into the coast (`MOMENTUM_TAU_MS` in index.ts)
+  // glides the camera ~100px — measured, not estimated — from a gesture the
+  // viewer experienced as a click. During a layout transition that carried
+  // the node they had just toggled a hundred pixels off its pinned spot, a
+  // little further with every click, until the chart left the screen. What
+  // actually distinguishes a fling is its SIZE, not its instantaneous speed:
+  // by release a flicking finger has covered tens of pixels inside the
+  // window, so a floor a few times `DRAG_THRESHOLD_PX` removes the
+  // click-jerk coast without costing any deliberate flick. Straight-line
+  // displacement rather than `travelled`, which sums absolute per-event
+  // deltas and so would count jitter that goes nowhere.
+  const MIN_FLING_TRAVEL_PX = 16
   let moveSamples: { t: number; x: number; y: number }[] = []
 
   const localPoint = (event: { clientX: number; clientY: number }) => {
@@ -219,6 +243,7 @@ export function attachInput(
     dragging = true
     claimed = false
     travelled = 0
+    panning = false
     lastX = event.clientX
     lastY = event.clientY
     downX = event.clientX
@@ -265,17 +290,38 @@ export function attachInput(
     // Crossing the threshold is the moment the gesture stops being ambiguous,
     // so it is the moment to ask whether someone else wants it. Offered from
     // the PRESS point, not from here — see `onDragStart`.
-    if (travelled > DRAG_THRESHOLD_PX) {
-      const from = localPoint({ clientX: downX, clientY: downY })
-      if (callbacks.onDragStart(from.x, from.y, downTarget)) {
-        claimed = true
-        const point = localPoint(event)
-        callbacks.onDragMove(point.x, point.y)
-        return
-      }
+    //
+    // Below it, nothing happens at all: no `onDragStart` offer, and — this is
+    // the part that used to be missing — no camera move either. The camera
+    // change itself was harmless (a pixel or two, invisible), but reporting it
+    // through `setCamera` is how this layer says "the user is panning", and
+    // the vanilla layer answers that by dropping the toggle camera anchor (see
+    // `cancelCameraAnimation`'s `dropToggleAnchor`). So a plain CLICK during an
+    // expand/collapse — a click anywhere, including on the background — killed
+    // the anchor holding the toggled node still, and the rest of the
+    // transition then played out with nothing pinning it: the whole chart slid
+    // by however far it had left to travel, carrying the node the viewer was
+    // watching off screen with it. And a real click always travels: a mouse
+    // emits a move or two under the finger, a trackpad always does.
+    if (travelled <= DRAG_THRESHOLD_PX) return
+    const from = localPoint({ clientX: downX, clientY: downY })
+    if (callbacks.onDragStart(from.x, from.y, downTarget)) {
+      claimed = true
+      const point = localPoint(event)
+      callbacks.onDragMove(point.x, point.y)
+      return
     }
 
-    callbacks.setCamera(pan(callbacks.getCamera(), dx, dy))
+    // The first move past the threshold pans from the PRESS point, not from
+    // the previous move: the few pixels held back while the gesture was still
+    // ambiguous are applied here in one go, so a pan tracks the pointer
+    // exactly rather than lagging the threshold behind it forever.
+    callbacks.setCamera(
+      panning
+        ? pan(callbacks.getCamera(), dx, dy)
+        : pan(callbacks.getCamera(), event.clientX - downX, event.clientY - downY),
+    )
+    panning = true
 
     const now = performance.now()
     moveSamples.push({ t: now, x: event.clientX, y: event.clientY })
@@ -342,7 +388,14 @@ export function attachInput(
     const last = moveSamples[moveSamples.length - 1]
     if (first !== undefined && last !== undefined) {
       const dt = last.t - first.t
-      if (dt >= MIN_VELOCITY_SAMPLE_MS) {
+      // Both floors — see their docblocks above: enough TIME in the window
+      // for the division to mean anything, and enough TRAVEL in it for the
+      // gesture to have been a fling rather than the few pixels a hand
+      // moves during an ordinary click.
+      if (
+        dt >= MIN_VELOCITY_SAMPLE_MS &&
+        Math.hypot(last.x - first.x, last.y - first.y) >= MIN_FLING_TRAVEL_PX
+      ) {
         callbacks.onRelease((last.x - first.x) / dt, (last.y - first.y) / dt)
       }
     }

--- a/packages/core/src/klad.browser.test.ts
+++ b/packages/core/src/klad.browser.test.ts
@@ -1845,6 +1845,61 @@ describe('createKlad', () => {
 
   // --- input routes through the chart host, not just the canvas -----------
 
+  it('grows a revealing card by SCALING it, so its content never reflows on the way in', async () => {
+    // The owner, watching a fast expand: "it looks like it comes out of its
+    // own top-left." It did. The element used to be sized to the interpolated
+    // box, so at the start of a reveal it was a few pixels wide and its text,
+    // padding and everything else re-wrapped to that — a full-size-looking
+    // card pinned by its top-left corner while the box grew around it, rather
+    // than a card growing out of the point the reveal starts from.
+    //
+    // The element is now laid out at its FINISHED size for the whole
+    // transition and scaled down to the interpolated one, which is what the
+    // canvas node beside it has always done.
+    const chart = make({
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+      ],
+      collapsedByDefault: true,
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )
+    expect(cardOf('b')).toBeUndefined() // still shut
+
+    chart.api.expand('a')
+    await nextFrame()
+    await nextFrame()
+
+    const card = cardOf('b')!
+    expect(card).not.toBeUndefined()
+    // Laid out at the settled size — NOT collapsed to the interpolated width,
+    // which is what made the content reflow.
+    expect(card.style.width).toBe('120px')
+    expect(card.style.height).toBe('48px')
+    // ...and scaled down instead. Early in the reveal that scale is well
+    // under 1; `zoomTo(1)` means the camera contributes exactly 1 to it.
+    const scale = Number(/scale\(([\d.]+)\)/.exec(card.style.transform)?.[1] ?? '1')
+    expect(scale).toBeGreaterThanOrEqual(0)
+    expect(scale).toBeLessThan(1)
+
+    // And by the end it is back to its own size at scale 1, so nothing is
+    // left permanently shrunk.
+    await settleTransition()
+    await settleTransition()
+    const settledCard = cardOf('b')!
+    expect(settledCard.style.width).toBe('120px')
+    expect(Number(/scale\(([\d.]+)\)/.exec(settledCard.style.transform)?.[1] ?? '0')).toBeCloseTo(1, 2)
+    chart.destroy()
+  })
+
   it('pans when a drag starts on an overlay card', async () => {
     const chart = make({ renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id) })
     chart.api.fit()

--- a/packages/core/src/klad.browser.test.ts
+++ b/packages/core/src/klad.browser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { createOverlay } from './overlay.js'
 import {
   createKlad,
   type NodeContext,
@@ -1845,59 +1846,49 @@ describe('createKlad', () => {
 
   // --- input routes through the chart host, not just the canvas -----------
 
-  it('grows a revealing card by SCALING it, so its content never reflows on the way in', async () => {
+  it('sizes an overlay card to its SETTLED box and carries the difference as scale', async () => {
     // The owner, watching a fast expand: "it looks like it comes out of its
-    // own top-left." It did. The element used to be sized to the interpolated
-    // box, so at the start of a reveal it was a few pixels wide and its text,
-    // padding and everything else re-wrapped to that — a full-size-looking
-    // card pinned by its top-left corner while the box grew around it, rather
-    // than a card growing out of the point the reveal starts from.
+    // own top-left." It did. A DOM element is not a drawing: size it to the
+    // box it is being DRAWN at and its text, padding and avatar re-wrap to
+    // whatever that width currently is, so a card mid-transition was a
+    // full-size-looking thing pinned by its top-left corner while the box
+    // caught up around it. The canvas node beside it was scaling correctly
+    // the whole time, which is why this only ever showed on the card
+    // examples.
     //
-    // The element is now laid out at its FINISHED size for the whole
-    // transition and scaled down to the interpolated one, which is what the
-    // canvas node beside it has always done.
-    const chart = make({
-      data: [
-        { id: 'a', name: 'a' },
-        { id: 'b', parentId: 'a', name: 'b' },
-      ],
-      collapsedByDefault: true,
-      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
-    })
-    chart.api.zoomTo(1)
-    await settle()
-    await nextFrame()
+    // Driven directly, because the interpolated and settled boxes have to
+    // DIFFER for there to be anything to assert, and which transitions make
+    // them differ is the engine's business and changes with its choreography.
+    // The contract this pins is the overlay's own: lay out at the settled
+    // size, put every difference in the transform.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const overlay = createOverlay(host, { render: (el, item) => (el.textContent = item.id) })
+    const settledBox = { x: 100, y: 50, w: 200, h: 80 }
+    const drawnBox = { x: 140, y: 70, w: 100, h: 40 } // half size, part way there
 
-    const cardOf = (id: string) =>
-      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
-        (each) => each.textContent === id,
-      )
-    expect(cardOf('b')).toBeUndefined() // still shut
+    overlay.update(
+      [{ index: 0, id: 'n' }],
+      () => drawnBox,
+      { x: 0, y: 0, k: 1 },
+      () => 1,
+      () => settledBox,
+    )
 
-    chart.api.expand('a')
-    await nextFrame()
-    await nextFrame()
+    const card = host.querySelector('.klad-overlay-node') as HTMLElement
+    expect(card).not.toBeNull()
+    // Laid out at the size it will settle at — NOT the 100x40 it is being
+    // drawn at, which is what made the content reflow.
+    expect(card.style.width).toBe('200px')
+    expect(card.style.height).toBe('80px')
+    // ...and the difference carried by the transform instead, so it lands on
+    // screen exactly where the canvas draws it: 100/200 of its own size, at
+    // the drawn box's top-left corner.
+    expect(card.style.transform).toContain('scale(0.5)')
+    expect(card.style.transform).toContain('translate3d(140px, 70px, 0')
 
-    const card = cardOf('b')!
-    expect(card).not.toBeUndefined()
-    // Laid out at the settled size — NOT collapsed to the interpolated width,
-    // which is what made the content reflow.
-    expect(card.style.width).toBe('120px')
-    expect(card.style.height).toBe('48px')
-    // ...and scaled down instead. Early in the reveal that scale is well
-    // under 1; `zoomTo(1)` means the camera contributes exactly 1 to it.
-    const scale = Number(/scale\(([\d.]+)\)/.exec(card.style.transform)?.[1] ?? '1')
-    expect(scale).toBeGreaterThanOrEqual(0)
-    expect(scale).toBeLessThan(1)
-
-    // And by the end it is back to its own size at scale 1, so nothing is
-    // left permanently shrunk.
-    await settleTransition()
-    await settleTransition()
-    const settledCard = cardOf('b')!
-    expect(settledCard.style.width).toBe('120px')
-    expect(Number(/scale\(([\d.]+)\)/.exec(settledCard.style.transform)?.[1] ?? '0')).toBeCloseTo(1, 2)
-    chart.destroy()
+    overlay.destroy()
+    host.remove()
   })
 
   it('pans when a drag starts on an overlay card', async () => {

--- a/packages/core/src/klad.browser.test.ts
+++ b/packages/core/src/klad.browser.test.ts
@@ -48,7 +48,7 @@ const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r(null)))
 const settle = () => new Promise<void>((resolve) => setTimeout(() => resolve(), 260))
 
 // A single-node expand/collapse now runs the engine's own staged layout
-// transition (see engine.ts's `TRANSITION_DURATION_MS`, currently 450ms —
+// transition (see engine.ts's `TRANSITION_DURATION_MS`, currently 390ms —
 // two phases plus a small overlap), and the camera anchor rides along with
 // it for as long as that transition runs. That is LONGER than the 200ms
 // camera-tween `settle()` above waits out, so a test that toggles a node and
@@ -1200,6 +1200,36 @@ describe('createKlad', () => {
     chart.destroy()
   })
 
+  it('does not coast after a click-sized drag: the camera moves by the drag and not a pixel further', async () => {
+    // The owner's "during an expand/collapse, even the tiniest drag makes
+    // the camera slide": a click made by a hand in motion travels ~6px in
+    // ~10ms, and that used to divide out to a "velocity" the coast turned
+    // into a ~100px glide (measured) — sixteen times the gesture, once per
+    // click, until the chart left the screen. The transition is incidental
+    // (it is just when the sliding is most visible and most destructive, the
+    // toggled node being carried off its pinned spot), so this asserts the
+    // primitive at idle where the expectation is exact: a 6px drag moves
+    // the camera 6px, full stop. See MIN_FLING_TRAVEL_PX in input.ts.
+    const chart = make()
+    await nextFrame()
+    await nextFrame()
+
+    const canvas = document.querySelector('canvas')!
+    const before = chart.api.getState().camera
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 300, bubbles: true }))
+    await new Promise((r) => setTimeout(r, 10))
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 406, clientY: 300, bubbles: true }))
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: 406, clientY: 300, bubbles: true }))
+    // Long enough that a coast, had one started, would have carried tens of
+    // pixels (release velocity x MOMENTUM_TAU_MS decays well inside this).
+    await new Promise((r) => setTimeout(r, 700))
+
+    const after = chart.api.getState().camera
+    expect(after.x - before.x).toBeCloseTo(6, 0)
+    expect(after.y - before.y).toBeCloseTo(0, 0)
+    chart.destroy()
+  })
+
   // --- auto-pan on toggle --------------------------------------------------
 
   it('pins the toggled node to its exact on-screen position through an expand', async () => {
@@ -1841,6 +1871,301 @@ describe('createKlad', () => {
     chart.destroy()
   })
 
+  // --- a tap during a toggle is not a pan --------------------------------
+  //
+  // Both of these are the same report from the owner: "open or close a node,
+  // click again while it is animating, and the camera slides — the node you
+  // were looking at leaves the screen." Two separate causes, one symptom.
+
+  it('holds the toggle anchor through a tap: a click during the transition leaves the camera where an undisturbed one would', async () => {
+    // A wide row under 'b', so collapsing it takes real width out of the
+    // layout: 'b' itself is recentred a long way, and the anchor has to move
+    // the camera by exactly that to hold it still. A toggle that moved the
+    // camera by nothing would pass this test no matter what.
+    const chart = make({
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+        { id: 'b1', parentId: 'b', name: 'b1' },
+        { id: 'b2', parentId: 'b', name: 'b2' },
+        { id: 'b3', parentId: 'b', name: 'b3' },
+        { id: 'b4', parentId: 'b', name: 'b4' },
+        { id: 'c', parentId: 'a', name: 'c' },
+      ],
+    })
+    await settle()
+    const canvas = document.querySelector('canvas')!
+    // A press that travels a pixel or two, which is every real click: a mouse
+    // emits a move under the finger, a trackpad always does. That move used to
+    // be reported as a pan, and a pan drops the anchor holding the toggled
+    // node — so the rest of the layout finished its move unheld and the whole
+    // chart lurched by the travel that was left.
+    const tap = (x: number, y: number) => {
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: x, clientY: y, bubbles: true }))
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: x + 1, clientY: y, bubbles: true }))
+      window.dispatchEvent(new PointerEvent('pointerup', { clientX: x + 1, clientY: y, bubbles: true }))
+    }
+
+    // Control: the same toggle, undisturbed.
+    chart.api.collapse('b')
+    await settleTransition()
+    const undisturbed = chart.api.getState().camera
+    chart.api.expand('b')
+    await settleTransition()
+    const opened = chart.api.getState().camera
+    // The scenario only means anything if the toggle moves the camera at all —
+    // the anchor is what moves it, holding 'b' still while the layout reflows.
+    expect(Math.abs(opened.x - undisturbed.x) + Math.abs(opened.y - undisturbed.y)).toBeGreaterThan(1)
+
+    // Now the same collapse, with a click on empty canvas partway through.
+    chart.api.collapse('b')
+    await nextFrame()
+    await nextFrame()
+    tap(5, 5)
+    await settleTransition()
+
+    const disturbed = chart.api.getState().camera
+    expect(disturbed.x).toBeCloseTo(undisturbed.x, 5)
+    expect(disturbed.y).toBeCloseTo(undisturbed.y, 5)
+    chart.destroy()
+  })
+
+  it('pins the second node when a toggle lands while another one is still animating', async () => {
+    // Toggling in quick succession — the owner's "click one, click the next
+    // before it has finished". The anchor has to switch to the new node and
+    // hold it from wherever it is being DRAWN at that instant, not from where
+    // the previous transition's final layout says it is.
+    const chart = make({
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+        { id: 'b1', parentId: 'b', name: 'b1' },
+        { id: 'b2', parentId: 'b', name: 'b2' },
+        { id: 'b3', parentId: 'b', name: 'b3' },
+        { id: 'b4', parentId: 'b', name: 'b4' },
+        { id: 'c', parentId: 'a', name: 'c' },
+        { id: 'c1', parentId: 'c', name: 'c1' },
+        { id: 'c2', parentId: 'c', name: 'c2' },
+      ],
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )!
+
+    chart.api.collapse('b')
+    await new Promise<void>((resolve) => setTimeout(resolve, 100))
+    const before = cardOf('c').getBoundingClientRect()
+    chart.api.collapse('c')
+    await settleTransition()
+    await settleTransition()
+    const after = cardOf('c').getBoundingClientRect()
+
+    // Within a pixel: both ends are read from real rendered frames, so a
+    // frame's worth of the first transition can still land between the two
+    // reads. What this rules out is the node leaving the spot the viewer
+    // clicked, which is tens or hundreds of pixels.
+    expect(after.left).toBeCloseTo(before.left, 0)
+    expect(after.top).toBeCloseTo(before.top, 0)
+    chart.destroy()
+  })
+
+  it('hit-tests a tap against what is DRAWN mid-transition, not against the layout it is heading for', async () => {
+    const toggles: string[] = []
+    // 'b' carries a wide row of children, so collapsing it takes a lot of
+    // width out of the layout and everything to its right travels a long way
+    // — further than a card is wide, which is what makes the two answers
+    // (drawn vs. settled) genuinely different at the same point.
+    const chart = make({
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+        { id: 'b1', parentId: 'b', name: 'b1' },
+        { id: 'b2', parentId: 'b', name: 'b2' },
+        { id: 'b3', parentId: 'b', name: 'b3' },
+        { id: 'b4', parentId: 'b', name: 'b4' },
+        { id: 'c', parentId: 'a', name: 'c' },
+        { id: 'c1', parentId: 'c', name: 'c1' },
+      ],
+      toggleOnNodeClick: true,
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.on('toggle', (event) => toggles.push(event.id))
+    chart.api.zoomTo(1)
+    await settle()
+    await nextFrame()
+
+    // Where 'c' is NOW, before anything moves — and, two frames into the
+    // collapse below, still where it is being drawn: a collapse reflows in
+    // phase 2, so 'c' has not started travelling yet. Its box in the layout
+    // the engine is heading for is already a long way from here.
+    const cards = [...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]
+    const card = cards.find((each) => each.textContent === 'c')!
+    expect(card).not.toBeUndefined()
+    const rect = card.getBoundingClientRect()
+    const x = rect.left + rect.width / 2
+    const y = rect.top + rect.height / 2
+
+    chart.api.collapse('b')
+    await nextFrame()
+    await nextFrame()
+
+    // Every hit test in the engine answers from the settled layout, which
+    // mid-transition is not where 'c' is — so this tap used to toggle
+    // whatever ends up under the point instead (or nothing at all), and then
+    // anchored the camera on that, which is what "it jumps somewhere
+    // unrelated" was.
+    const canvas = document.querySelector('canvas')!
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: x, clientY: y, bubbles: true }))
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: x, clientY: y, bubbles: true }))
+    await settleTransition()
+
+    expect(toggles).toEqual(['b', 'c'])
+    chart.destroy()
+  })
+
+  // The worker-path counterpart of the anchor tests above. The three tests
+  // before this one all run in-process (`worker: false`), where the awaited
+  // render resolves in a microtask and nothing can interleave with the frame
+  // callback. The playground — where the owner reproduced "click a node
+  // fast a dozen times and the chart walks off screen" — runs the worker
+  // path, where that await is a real round trip and a fast click lands
+  // INSIDE it. These two pin down what that opened up.
+
+  it('promotes a toggle anchor only against the layout its own toggle produced (worker path)', async () => {
+    // The sharpest form of the race: toggle, then toggle back in the very
+    // next animation-frame callback. The chart's own frame callback for the
+    // first toggle registered first, so it is already suspended at `await
+    // chartHost.render()` when the second toggle lands — the second toggle
+    // re-arms the camera anchor, but the render that await is waiting on was
+    // posted BEFORE the second toggle and reflects only the first. Promoting
+    // the new anchor against that older frame built it from the collapsed
+    // layout the engine had already abandoned: the camera then spent a whole
+    // transition carrying the root to where the COLLAPSED layout put it —
+    // the full distance between the two layouts (340px in this very tree),
+    // once per race hit, which is the owner's walk.
+    const chart = make({
+      worker: true,
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'a1', parentId: 'a', name: 'a1' },
+        { id: 'a2', parentId: 'a', name: 'a2' },
+        { id: 'a3', parentId: 'a', name: 'a3' },
+        { id: 'a4', parentId: 'a', name: 'a4' },
+        { id: 'a5', parentId: 'a', name: 'a5' },
+        { id: 'a6', parentId: 'a', name: 'a6' },
+      ],
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )!
+
+    const before = cardOf('a').getBoundingClientRect()
+
+    chart.api.collapse('a')
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => {
+        chart.api.expand('a')
+        resolve()
+      }),
+    )
+    await settleTransition()
+    await settleTransition()
+
+    const after = cardOf('a').getBoundingClientRect()
+    expect(after.left).toBeCloseTo(before.left, 0)
+    expect(after.top).toBeCloseTo(before.top, 0)
+    chart.destroy()
+  })
+
+  it('never lets a dozen rapid toggles walk the toggled node off its spot (worker path)', async () => {
+    // The owner's actual gesture, minus the mouse: 10–15 toggles of the same
+    // node at varying speeds, some landing inside the previous frame's
+    // render await (the race above), some mid-transition, some between
+    // transitions. The root's card is sampled EVERY FRAME for the whole run,
+    // because the failure is not where the node ends — a symmetric walk can
+    // wander hundreds of pixels and still happen to finish near the start —
+    // but how far it ever strays from the spot the anchor promised to hold.
+    const chart = make({
+      worker: true,
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'a1', parentId: 'a', name: 'a1' },
+        { id: 'a2', parentId: 'a', name: 'a2' },
+        { id: 'a3', parentId: 'a', name: 'a3' },
+        { id: 'a4', parentId: 'a', name: 'a4' },
+        { id: 'a5', parentId: 'a', name: 'a5' },
+        { id: 'a6', parentId: 'a', name: 'a6' },
+      ],
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )!
+
+    const start = cardOf('a').getBoundingClientRect()
+    let maxDrift = 0
+    let sampling = true
+    const sample = () => {
+      const rect = cardOf('a')?.getBoundingClientRect()
+      if (rect !== undefined) {
+        maxDrift = Math.max(maxDrift, Math.abs(rect.left - start.left) + Math.abs(rect.top - start.top))
+      }
+      if (sampling) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+
+    // Alternating collapse/expand of the root, with the gap between clicks
+    // cycling through "the very next frame" (inside the previous await),
+    // "mid-transition" and "transition nearly over" — the mix a real hand
+    // produces.
+    let isOpen = true
+    const toggle = () => {
+      if (isOpen) chart.api.collapse('a')
+      else chart.api.expand('a')
+      isOpen = !isOpen
+    }
+    const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+    for (let i = 0; i < 6; i++) {
+      toggle()
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => {
+          toggle()
+          resolve()
+        }),
+      )
+      await wait(i % 2 === 0 ? 60 : 180)
+    }
+    await settleTransition()
+    await settleTransition()
+    sampling = false
+
+    // Tens of pixels would already be visible sloshing; the pre-fix walk was
+    // hundreds (one layout-width per race hit). A few pixels of slack covers
+    // the one frame between a mid-flight toggle and its promotion, where the
+    // camera deliberately holds still while the new curve creeps off zero.
+    expect(maxDrift).toBeLessThan(8)
+    chart.destroy()
+  })
+
   it("does not pan on a tap that lands on a card's own button, and the button's click still fires", async () => {
     let toggled = false
     const chart = make({
@@ -1925,6 +2250,164 @@ describe('createKlad', () => {
     await nextFrame()
 
     expect(toggles).toEqual([])
+    chart.destroy()
+  })
+
+  it('will not let a drag move the toggled node while its transition is running', async () => {
+    // The owner's rule, in one sentence: for as long as a branch is opening or
+    // closing, the node that was clicked stays exactly where it was clicked,
+    // and a pan cannot take it off that spot. A press during a toggle is part
+    // of the toggling — hand-drift under a click, a nudge, an impatient second
+    // click — not a request to go and look somewhere else, and treating it as
+    // one is what walked the chart off screen a few pixels at a time.
+    const chart = make({
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+        { id: 'b1', parentId: 'b', name: 'b1' },
+        { id: 'b2', parentId: 'b', name: 'b2' },
+        { id: 'b3', parentId: 'b', name: 'b3' },
+        { id: 'b4', parentId: 'b', name: 'b4' },
+        { id: 'c', parentId: 'a', name: 'c' },
+      ],
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )
+    const before = cardOf('b')!.getBoundingClientRect()
+
+    chart.api.collapse('b')
+    await nextFrame()
+    await nextFrame()
+
+    // A real drag, well past `DRAG_THRESHOLD_PX` — not hand-jitter, a
+    // deliberate 40px pull — landing while the transition runs.
+    const canvas = document.querySelector('canvas')!
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 500, bubbles: true }))
+    for (let i = 1; i <= 4; i++) {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { clientX: 400 + i * 10, clientY: 500, bubbles: true }),
+      )
+      await nextFrame()
+    }
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: 440, clientY: 500, bubbles: true }))
+    await settleTransition()
+    await settleTransition()
+
+    const after = cardOf('b')!.getBoundingClientRect()
+    expect(after.left).toBeCloseTo(before.left, 0)
+    expect(after.top).toBeCloseTo(before.top, 0)
+
+    // ...and the moment the transition is over, the same gesture pans again:
+    // the rule is a half-second of priority, not a mode.
+    const settledCamera = chart.api.getState().camera.x
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 400, clientY: 500, bubbles: true }))
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 440, clientY: 500, bubbles: true }))
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: 440, clientY: 500, bubbles: true }))
+    await nextFrame()
+    expect(chart.api.getState().camera.x).toBeCloseTo(settledCamera + 40, 0)
+    chart.destroy()
+  })
+
+  it('holds the root under a burst of real clicks on its own card (worker path)', async () => {
+    // The owner's gesture as the browser actually delivers it, which is what
+    // the API-driven burst above cannot cover: a press, a pixel or six of hand
+    // movement under the finger, a release, at a FIXED screen point, over and
+    // over. Every layer is in play here and only here — the tap's hit test
+    // against drawn geometry, the double-click window swallowing every second
+    // tap, `requestOpen` vs `setOpenFlag`, the release's fling test — on top
+    // of the worker round trip the anchor promotion races with.
+    //
+    // The root specifically, because it is where the anchor does the most
+    // work: a tidy layout centres it over its whole subtree, so collapsing it
+    // moves its own box by half the tree's width, and the camera has to travel
+    // exactly that far to leave it where the viewer clicked. Any error is
+    // largest here.
+    const chart = make({
+      worker: true,
+      toggleOnNodeClick: true,
+      data: [
+        { id: 'a', name: 'a' },
+        { id: 'a1', parentId: 'a', name: 'a1' },
+        { id: 'a2', parentId: 'a', name: 'a2' },
+        { id: 'a3', parentId: 'a', name: 'a3' },
+        { id: 'a4', parentId: 'a', name: 'a4' },
+        { id: 'a5', parentId: 'a', name: 'a5' },
+        { id: 'a6', parentId: 'a', name: 'a6' },
+      ],
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
+    await settle()
+    await nextFrame()
+
+    const cardOf = (id: string) =>
+      ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === id,
+      )
+    const start = cardOf('a')!.getBoundingClientRect()
+    const px = start.left + start.width / 2
+    const py = start.top + start.height / 2
+
+    let maxDrift = 0
+    let sampling = true
+    const sample = () => {
+      const rect = cardOf('a')?.getBoundingClientRect()
+      if (rect !== undefined) {
+        maxDrift = Math.max(maxDrift, Math.abs(rect.left - start.left) + Math.abs(rect.top - start.top))
+      }
+      if (sampling) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+
+    const canvas = document.querySelector('canvas')!
+    // `jitter` is the hand: a click delivered by a moving hand travels a few
+    // pixels between press and release, which is the whole reason this is not
+    // the same test as the API burst.
+    const click = (jitter: number) => {
+      canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: px, clientY: py, bubbles: true }))
+      if (jitter > 0) {
+        window.dispatchEvent(
+          new PointerEvent('pointermove', { clientX: px + jitter, clientY: py, bubbles: true }),
+        )
+      }
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { clientX: px + jitter, clientY: py, bubbles: true }),
+      )
+    }
+    const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+    // Gaps straddle `DOUBLE_CLICK_MS` (300) so some taps toggle and some are
+    // swallowed as the second half of a double click, exactly as they do under
+    // a real hand — and both kinds land mid-transition.
+    const gaps = [40, 120, 320, 80, 420, 60, 340, 100, 380, 50, 300, 90]
+    for (let i = 0; i < gaps.length; i++) {
+      // 1-3px: what a hand does under a click, and below `DRAG_THRESHOLD_PX`,
+      // so every one of these is a TAP. A press that travels past the
+      // threshold is a pan and is supposed to move the chart — that case has
+      // its own test above ("the camera moves by the drag and not a pixel
+      // further"), and mixing it in here would mean asserting against a
+      // moving target.
+      click(1 + (i % 3))
+      await wait(gaps[i]!)
+    }
+    await settleTransition()
+    await settleTransition()
+    sampling = false
+
+    // Two pixels, and that is measured rather than generous: with the toggle
+    // holding the camera from the click itself (not from the frame that
+    // promotes its anchor), a dozen real clicks leave the root visually
+    // nailed down. The failure this guards began at 334px — the root off the
+    // screen — and the last version of it, before the pending-anchor hold,
+    // still wobbled a few pixels per click.
+    expect(maxDrift).toBeLessThan(2)
     chart.destroy()
   })
 
@@ -2044,13 +2527,22 @@ describe('createKlad', () => {
   })
 
   it('toggles once, not twice, on a double click', async () => {
-    // autoPanOnToggle disabled, and the tap coordinate recomputed after the
-    // first tap, so a real effect of THIS test's own toggle — the root's
-    // own box can shift once it has no visible children to centre over,
+    // autoPanOnToggle disabled, and the tap coordinate re-read from the DRAWN
+    // card before each tap, so a real effect of THIS test's own toggle — the
+    // root's own box shifts once it has no visible children to centre over,
     // independently of any camera move — doesn't make the second tap of the
-    // pair miss the node and turn this into a false negative.
-    const chart = make({ toggleOnNodeClick: true, autoPanOnToggle: false })
-    chart.api.fit()
+    // pair miss the node and turn this into a false negative. It has to be
+    // the drawn position rather than `rootScreenCentre` (which is the settled
+    // one): the second tap lands one frame into the transition, when the root
+    // has not travelled yet, and a tap resolves against what is on the canvas
+    // — see `hitTestDrawn`.
+    const chart = make({
+      toggleOnNodeClick: true,
+      autoPanOnToggle: false,
+      renderNode: (el: HTMLElement, ctx: { id: string }) => (el.textContent = ctx.id),
+    })
+    chart.api.zoomTo(1)
+    await settle()
     await nextFrame()
 
     const toggles: unknown[] = []
@@ -2059,11 +2551,13 @@ describe('createKlad', () => {
     chart.on('nodeDblClick', (e) => dblclicks.push(e.id))
 
     const canvas = document.querySelector('canvas')!
-    const rect = canvas.getBoundingClientRect()
     const tapRoot = () => {
-      const state = chart.api.getState()
-      const sx = rect.left + state.rootScreenCentre.x
-      const sy = rect.top + state.rootScreenCentre.y
+      const card = ([...document.querySelectorAll('.klad-overlay-node')] as HTMLElement[]).find(
+        (each) => each.textContent === 'a',
+      )!
+      const box = card.getBoundingClientRect()
+      const sx = box.left + box.width / 2
+      const sy = box.top + box.height / 2
       canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: sx, clientY: sy, bubbles: true }))
       window.dispatchEvent(new PointerEvent('pointerup', { clientX: sx, clientY: sy, bubbles: true }))
     }

--- a/packages/core/src/overlay.ts
+++ b/packages/core/src/overlay.ts
@@ -54,12 +54,25 @@ export function createOverlay(container: HTMLElement, callbacks: OverlayCallback
      * edge, so a card ignoring it paints its content — unclipped, since the
      * element it overflows is 0x0 — as a bubble hanging off the parent until
      * the reveal finally starts.
+     *
+     * `settledBoxOf` is the same node's box in the FINISHED layout, and it is
+     * what the element is actually sized to; the interpolated box only decides
+     * where it sits and how far it is scaled down. That split is the whole
+     * difference between a card that GROWS and a card that REFLOWS. A DOM
+     * element is not a drawing: give it the interpolated width and its text,
+     * its padding and its avatar all re-wrap to whatever that width currently
+     * is, so a reveal read as a full-size card pinned by its top-left corner
+     * while the box caught up around it — the owner's "it looks like it comes
+     * out of its own top-left". Laying it out ONCE at the size it will end up
+     * and scaling that down to the interpolated size makes it grow the way the
+     * canvas node beside it does, out of the point the reveal starts from.
      */
     update(
       items: readonly OverlayItem[],
       boxOf: (index: number) => { x: number; y: number; w: number; h: number } | null,
       camera: Camera,
       alphaOf: (index: number) => number,
+      settledBoxOf: (index: number) => { x: number; y: number; w: number; h: number } | null = boxOf,
     ): void {
       activeCount = 0
       for (const item of items) {
@@ -67,9 +80,17 @@ export function createOverlay(container: HTMLElement, callbacks: OverlayCallback
         if (box === null) continue
         const element = acquire()
         const screen = worldToScreen(camera, box.x, box.y)
-        element.style.width = `${box.w}px`
-        element.style.height = `${box.h}px`
-        element.style.transform = `translate3d(${screen.x}px, ${screen.y}px, 0) scale(${camera.k})`
+        // The settled size for the layout, the interpolated one for the
+        // scale — see the docblock. Falls back to the box itself when there
+        // is no settled answer (and they are the same object outside a
+        // transition anyway, which is every frame but a few hundred
+        // milliseconds after a toggle), and guards a zero width so the first
+        // frame of a reveal cannot divide by it.
+        const settled = settledBoxOf(item.index) ?? box
+        const grow = settled.w > 0 ? box.w / settled.w : 1
+        element.style.width = `${settled.w}px`
+        element.style.height = `${settled.h}px`
+        element.style.transform = `translate3d(${screen.x}px, ${screen.y}px, 0) scale(${camera.k * grow})`
         // Cleared to '' rather than '1' at full opacity so a card that is not
         // fading carries no inline opacity at all — the steady state leaves
         // the element exactly as it was before this feature existed, and a

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -893,93 +893,6 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(early.ghostAlpha[0]).toBeLessThan(0.3)
   })
 
-  it("grows a revealed node from its anchor's LIVE position, not the anchor's fixed pre-toggle box", () => {
-    // 'p' needs TWO children, not one — see the analogous sibling-reflow test
-    // in packages/core's orgchart.browser.test.ts for why: a single-child
-    // chain never widens its own subtree, so 'p' itself never needs to
-    // recentre. Two children side by side make 'p' noticeably wider once
-    // revealed, which is exactly what pushes 'p's OWN box, not just its
-    // sibling's, away from its pre-toggle position.
-    const NESTED: NodeData[] = [
-      { id: 'a' },
-      { id: 'p', parentId: 'a' },
-      { id: 'q1', parentId: 'p' },
-      { id: 'q2', parentId: 'p' },
-      { id: 'b', parentId: 'a' },
-    ]
-    const renderer = fakeRenderer()
-    const engine = createChartEngine(renderer)
-    const tree = normalize(NESTED)
-    engine.setAnimate(true)
-    engine.setViewport(800, 600, 1)
-    engine.setCamera({ x: 0, y: 0, k: 1 })
-    const open = new Uint8Array(tree.count).fill(1)
-    open[tree.idToIndex.get('p')!] = 0 // start collapsed: 'q1'/'q2' hidden
-    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'p', 'q1', 'q2', 'b'], open)
-    engine.render(1000) // settle the collapsed layout — no transition, the first layout
-
-    // Reads 'p's/'q1's AUTHORITATIVE (final, settled) box — unaffected by
-    // any in-progress transition, which only interpolates the DRAWN frame,
-    // never `engine.boxes` itself.
-    const finalBoxOf = (id: string): { x: number; y: number; w: number } => {
-      const src = tree.idToIndex.get(id)!
-      const idx = Array.from(engine.visibleToSource).indexOf(src)
-      expect(idx).toBeGreaterThanOrEqual(0)
-      const o = idx * 4
-      return { x: engine.boxes[o]!, y: engine.boxes[o + 1]!, w: engine.boxes[o + 2]! }
-    }
-    // Reads 'id's DRAWN (interpolated) box off the most recent frame —
-    // where it actually is on screen at that instant, unlike `finalBoxOf`.
-    const drawnBoxOf = (id: string): { x: number; y: number; w: number } => {
-      const src = tree.idToIndex.get(id)!
-      const idx = Array.from(engine.visibleToSource).indexOf(src)
-      expect(idx).toBeGreaterThanOrEqual(0)
-      const frame = renderer.frames.at(-1)!
-      const o = idx * 4
-      return { x: frame.boxes[o]!, y: frame.boxes[o + 1]!, w: frame.boxes[o + 2]! }
-    }
-    // 'p's own reveal-anchor EXIT point, x-axis only: for the default 'tb'
-    // orientation this test runs under, a revealed child's growth-start
-    // point is 'p's BOTTOM-edge, HORIZONTAL centre (see engine.ts's
-    // `exitBox`/`exitPointXY`) — i.e. `x + w/2`, not the box's raw top-left
-    // `x` a reveal used to grow from before that fix.
-    const exitX = (box: { x: number; w: number }): number => box.x + box.w / 2
-
-    const pBefore = finalBoxOf('p') // 'p's box while still collapsed
-
-    engine.setOpen(tree.idToIndex.get('p')!, true) // reveals q1/q2, recentring 'p'
-    engine.render(2000) // t=0 of the new transition
-    const pAfter = finalBoxOf('p') // 'p's NEW (final, post-relayout) box
-
-    // Sanity: the scenario this test exists to exercise. If 'p' didn't
-    // actually move between the two layouts, the discriminating assertion
-    // below would pass no matter which anchor box `render()` used.
-    expect(Math.abs(exitX(pAfter) - exitX(pBefore))).toBeGreaterThan(5)
-
-    // Overall progress 0.5 (half of `TRANSITION_MS`): for an EXPAND,
-    // `repositionRaw` (driving 'p's own reposition tween) is `phaseOneProgress`,
-    // three quarters done by this point (phase 1 spans the first ~67%) — 'p' is
-    // most of the way to `pAfter`. `emphasisRaw` (driving 'q1's reveal) is
-    // `phaseTwoProgress`, a quarter in (phase 2 starts around 33%) and eased,
-    // so 'q1' has barely left its growth-start point. So 'q1's rendered box
-    // should sit almost exactly on 'p's LIVE exit point (~exitX(pAfter)), not
-    // on 'p's stale pre-toggle exit point (exitX(pBefore)) — and the two are
-    // far enough apart (asserted above) that the bug this test guards
-    // against — growing from a fixed snapshot instead of the anchor's
-    // current position — would be unmistakable here.
-    engine.render(2000 + TRANSITION_MS / 2)
-    const pLive = drawnBoxOf('p')
-    const q1Rendered = drawnBoxOf('q1')
-
-    const distanceFromLiveAnchor = Math.abs(q1Rendered.x - exitX(pLive))
-    const distanceFromStaleAnchor = Math.abs(q1Rendered.x - exitX(pBefore))
-    expect(distanceFromLiveAnchor).toBeLessThan(distanceFromStaleAnchor)
-    // 'q1' should be reading as still close to wherever 'p's exit point
-    // actually is, not merely "closer to live than to stale by some margin"
-    // while still far from both.
-    expect(distanceFromLiveAnchor).toBeLessThan(Math.abs(exitX(pAfter) - exitX(pBefore)) / 2)
-  })
-
   it('carries a node caught mid-reveal at the size it was drawn, not at its finished size', () => {
     // Interrupting an expand: the children are halfway out of the parent,
     // still small, when a second toggle lands. What the new transition
@@ -1005,13 +918,12 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, true)
     engine.render(2000)
-    // Well into the reveal, but not finished: 'b1' is part-grown.
+    // Well into the reveal, but not finished: 'b1' is still on its way down.
     engine.render(2000 + TRANSITION_MS * 0.75)
     const b1Idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('b1')!)
-    const midWidth = renderer.frames.at(-1)!.boxes[b1Idx * 4 + 2]!
-    const finalWidth = engine.boxes[b1Idx * 4 + 2]!
-    expect(midWidth).toBeGreaterThan(0)
-    expect(midWidth).toBeLessThan(finalWidth * 0.95) // genuinely still growing
+    const midY = renderer.frames.at(-1)!.boxes[b1Idx * 4 + 1]!
+    const finalY = engine.boxes[b1Idx * 4 + 1]!
+    expect(midY).toBeLessThan(finalY - 1) // genuinely still travelling
 
     // The interrupting toggle. 'b1' leaves the tree, so it carries on as a
     // ghost — and the ghost has to start at the size it was just drawn at.
@@ -1020,11 +932,12 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBeGreaterThan(0)
 
-    let widest = 0
-    for (let g = 0; g < frame.ghostCount; g++) widest = Math.max(widest, frame.ghostBoxes[g * 4 + 2]!)
-    // Within a hair of where it was, and nowhere near the full-size jump.
-    expect(widest).toBeCloseTo(midWidth, 1)
-    expect(widest).toBeLessThan(finalWidth * 0.95)
+    let highest = Infinity
+    for (let g = 0; g < frame.ghostCount; g++) highest = Math.min(highest, frame.ghostBoxes[g * 4 + 1]!)
+    // Within a hair of where it was, and nowhere near the jump to its
+    // finished row that recomputing it used to produce.
+    expect(highest).toBeCloseTo(midY, 1)
+    expect(highest).toBeLessThan(finalY - 1)
   })
 
   it("grows a grandchild out of its OWN parent's exit point, not the toggled node's", () => {
@@ -1071,17 +984,17 @@ describe('ChartEngine expand/collapse transition', () => {
     const pLive = drawn('p')
     const q = drawn('q')
 
-    // Both ride the same reveal curve, and a revealed node grows out of a
-    // POINT, so how far along that curve is reads straight off 'p': its
-    // height runs 0 -> settled by exactly that fraction. That makes the
-    // expected position of 'q' an equation, and the two rules answer it
-    // differently.
-    const progress = pLive.h / settled('p').h
+    // Both ride the same reveal curve, so how far along it is reads straight
+    // off 'p': it travels from its own start (one mark below 'a') to its row
+    // by exactly that fraction. That makes the expected position of 'q' an
+    // equation, and the two rules answer it differently.
+    const pStart = a.y + a.h + REVEAL_REACH
+    const progress = (pLive.y - pStart) / (settled('p').y - pStart)
     expect(progress).toBeGreaterThan(0.1)
     expect(progress).toBeLessThan(0.9)
     const qSettledTop = settled('q').y
     const pOrigin = pLive.y + pLive.h + REVEAL_REACH
-    const aOrigin = a.y + a.h + REVEAL_REACH
+    const aOrigin = pStart
     const fromOwnParent = pOrigin + (qSettledTop - pOrigin) * progress
     const fromToggledNode = aOrigin + (qSettledTop - aOrigin) * progress
 
@@ -1122,16 +1035,15 @@ describe('ChartEngine expand/collapse transition', () => {
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
     const qStart = { x: frame.boxes[qIdx * 4]!, y: frame.boxes[qIdx * 4 + 1]! }
 
-    // Horizontal centre of 'a', and just past the tip of the mark hanging off
-    // its bottom edge — NOT 'a's top-left corner (the old, wrong growth-start
-    // point), not its centre, and not flush against its underside either.
-    expect(qStart.x).toBeCloseTo(aBox.x + aBox.w / 2, 6)
+    // Just past the tip of the mark hanging off 'a's bottom edge...
     expect(qStart.y).toBeCloseTo(aBox.y + aBox.h + REVEAL_REACH, 6)
-    // A genuine POINT, not sized like the parent — confirms this grows from
-    // a single spot and expands outward, rather than starting already
-    // shaped like the whole parent box.
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
+    // ...at its own size and in its own column. We know what size it is going
+    // to be, so it starts that size: growing it out of nothing put its
+    // top-left corner on the start point and left the card looking like it
+    // came out of that corner.
+    expect(frame.boxes[qIdx * 4]).toBeCloseTo(engine.boxes[qIdx * 4]!, 6)
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
   })
 
   it("shrinks a collapsing ghost back into the PARENT's exit edge, not its box origin/centre", () => {
@@ -1147,6 +1059,9 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, false) // collapse: 'q' becomes a ghost
     engine.render(1000)
+    // The size it leaves with, kept for the whole fold-away: a ghost slides
+    // back behind the mark rather than shrinking into it.
+    const ghostHeight = renderer.frames.at(-1)!.ghostBoxes[3]!
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
     const aBoxNow = {
@@ -1157,13 +1072,13 @@ describe('ChartEngine expand/collapse transition', () => {
     }
 
     // Right at the end of the transition (but still just inside it): the
-    // ghost has nearly finished shrinking toward its target, so its drawn
-    // box should sit almost exactly on 'a's exit point.
+    // ghost has nearly finished folding away, so its drawn box should sit
+    // almost exactly on its target — one mark's length below 'a'.
     engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
-    expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
     expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h + REVEAL_REACH, 1)
+    expect(frame.ghostBoxes[3]).toBeCloseTo(ghostHeight, 1)
   })
 
   it("grows a revealed child from the parent's TRAILING edge under lr orientation, not its bottom edge", () => {
@@ -1198,9 +1113,11 @@ describe('ChartEngine expand/collapse transition', () => {
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
     expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w + REVEAL_REACH, 6) // past the mark
-    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(aBox.y + aBox.h / 2, 6) // vertical centre
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
+    // Its own row and its own size — the growth axis is x here, so it is y
+    // that keeps what the child settles with.
+    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(engine.boxes[qIdx * 4 + 1]!, 6)
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
   })
 
   it('a second toggle mid-transition retargets from the current position instead of snapping', () => {

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -893,6 +893,66 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(early.ghostAlpha[0]).toBeLessThan(0.3)
   })
 
+  it("carries a node caught mid-COLLAPSE at the box it was drawn at, not at its parent's box", () => {
+    // Expand interrupting a collapse — the owner's fast clicking, and the one
+    // that took the longest to find. `render()` shrinks a ghost toward a
+    // POINT on its parent (the tip of the "more inside" mark), but the "where
+    // is everything right now" pass recomputed it toward the parent's whole
+    // BOX. Late in a collapse those two are as far apart as a card is big: the
+    // ghost was recorded at the parent's full-size box, and the expand landing
+    // on it started every child there — a card on top of the parent, at full
+    // size, flying down to its row. On a real page that was 240 frames out of
+    // ten fast toggles, all three children stacked exactly on the parent.
+    const FAN: NodeData[] = [
+      { id: 'a' },
+      { id: 'b1', parentId: 'a' },
+      { id: 'b2', parentId: 'a' },
+      { id: 'b3', parentId: 'a' },
+    ]
+    const renderer = fakeRenderer()
+    const engine = createChartEngine(renderer)
+    const tree = normalize(FAN)
+    engine.setAnimate(true)
+    engine.setViewport(800, 600, 1)
+    engine.setCamera({ x: 0, y: 0, k: 1 })
+    engine.setData(
+      toWireTree(tree),
+      sizesFor(tree.count),
+      ['a', 'b1', 'b2', 'b3'],
+      new Uint8Array(tree.count).fill(1),
+    )
+    engine.render(1000)
+
+    const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
+    const aBox = {
+      x: engine.boxes[aIdx * 4]!,
+      y: engine.boxes[aIdx * 4 + 1]!,
+      w: engine.boxes[aIdx * 4 + 2]!,
+      h: engine.boxes[aIdx * 4 + 3]!,
+    }
+
+    engine.setOpen(tree.idToIndex.get('a')!, false)
+    engine.render(2000)
+    // Late in the collapse: the ghosts have nearly finished shrinking into
+    // the tip, so they are small and nowhere near the parent's own box.
+    engine.render(2000 + TRANSITION_MS * 0.9)
+    const ghostWidth = renderer.frames.at(-1)!.ghostBoxes[2]!
+    expect(ghostWidth).toBeLessThan(aBox.w * 0.4)
+
+    // The interrupting expand, at that same instant.
+    engine.setOpen(tree.idToIndex.get('a')!, true)
+    engine.render(2000 + TRANSITION_MS * 0.9)
+    const frame = renderer.frames.at(-1)!
+    for (const id of ['b1', 'b2', 'b3']) {
+      const idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get(id)!)
+      expect(idx).toBeGreaterThanOrEqual(0)
+      const box = { x: frame.boxes[idx * 4]!, y: frame.boxes[idx * 4 + 1]!, w: frame.boxes[idx * 4 + 2]! }
+      // Where it was: small, below the parent. NOT the parent's box.
+      expect(box.w).toBeCloseTo(ghostWidth, 0)
+      expect(box.y).toBeGreaterThan(aBox.y + aBox.h)
+    }
+  })
+
   it('carries a node caught mid-reveal at the size it was drawn, not at its finished size', () => {
     // Interrupting an expand: the children are halfway out of the parent,
     // still small, when a second toggle lands. What the new transition

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -936,10 +936,11 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(pLiveBottom).toBeLessThan(pSettled.y + pSettled.h)
 
     // Both 'p' and 'q' ride the same reveal curve, so how far along it is can
-    // be read straight off 'p': its height runs 0 -> settled by exactly that
-    // fraction. That makes the expected position of 'q' an equation rather
-    // than a range — and one the two rules answer differently.
-    const progress = pLive.h / pSettled.h
+    // be read straight off 'p': it slides from 'a's bottom edge to its own
+    // row by exactly that fraction. That makes the expected position of 'q'
+    // an equation rather than a range — and one the two rules answer
+    // differently.
+    const progress = (pLive.y - (a.y + a.h)) / (pSettled.y - (a.y + a.h))
     expect(progress).toBeGreaterThan(0.1)
     expect(progress).toBeLessThan(0.9)
     const qSettledTop = settled('q').y
@@ -990,15 +991,21 @@ describe('ChartEngine expand/collapse transition', () => {
         w: frame.boxes[idx * 4 + 2]!,
         h: frame.boxes[idx * 4 + 3]!,
       }
-      const settled = { x: engine.boxes[idx * 4]!, w: engine.boxes[idx * 4 + 2]! }
+      const settledBox = {
+        x: engine.boxes[idx * 4]!,
+        w: engine.boxes[idx * 4 + 2]!,
+        h: engine.boxes[idx * 4 + 3]!,
+      }
 
-      // Under the parent's bottom edge, and flat against it.
+      // Tucked in behind the parent's bottom edge...
       expect(start.y).toBeCloseTo(aBox.y + aBox.h, 6)
-      expect(start.h).toBeCloseTo(0, 6)
-      // ...but already in its own column, at its own width — NOT collapsed
-      // onto the parent's horizontal centre.
-      expect(start.x).toBeCloseTo(settled.x, 6)
-      expect(start.w).toBeCloseTo(settled.w, 6)
+      // ...at full size, so the card slides rather than unfolds — no
+      // squashed line, no ballooning.
+      expect(start.h).toBeCloseTo(settledBox.h, 6)
+      expect(start.w).toBeCloseTo(settledBox.w, 6)
+      // ...and already in its own column, NOT collapsed onto the parent's
+      // horizontal centre.
+      expect(start.x).toBeCloseTo(settledBox.x, 6)
     }
 
     // The two children start apart, which is the whole point: the old
@@ -1024,6 +1031,7 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.setOpen(tree.idToIndex.get('a')!, false) // collapse: 'q' becomes a ghost
     engine.render(1000)
     const ghostStartX = renderer.frames.at(-1)!.ghostBoxes[0]!
+    const ghostHeight = renderer.frames.at(-1)!.ghostBoxes[3]!
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
     const aBoxNow = {
@@ -1045,9 +1053,10 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
-    // Flat against 'a's bottom edge...
+    // Tucked in behind 'a's bottom edge, still its own size — it slides
+    // away under the parent and fades, rather than shrinking to a line.
     expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h, 1)
-    expect(frame.ghostBoxes[3]).toBeCloseTo(0, 1)
+    expect(frame.ghostBoxes[3]).toBeCloseTo(ghostHeight, 1)
     // ...in its own column, keeping the width it had. `qWasX` is `null` only
     // if 'q' had already left the pruned tree, which is the case here — it
     // is a ghost — so the check is against the ghost's own starting x, which
@@ -1087,9 +1096,9 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
-    // Flat against 'a's trailing (right) edge, zero width...
+    // Tucked in behind 'a's trailing (right) edge, at full size...
     expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6)
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
     // ...and already in its own ROW, at its own height: the growth axis is x
     // here, so it is y that keeps what the child will settle with — the
     // mirror of what the tb case asserts about x. Not 'a's vertical centre,

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -972,6 +972,53 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(distanceFromLiveAnchor).toBeLessThan(Math.abs(exitX(pAfter) - exitX(pBefore)) / 2)
   })
 
+  it('carries a node caught mid-reveal at the size it was drawn, not at its finished size', () => {
+    // Interrupting an expand: the children are halfway out of the parent,
+    // still small, when a second toggle lands. What the new transition
+    // inherits has to be where they VISIBLY are — anything else is a jump,
+    // and this one jumped them to full size in their finished positions
+    // before setting off again, which is what the owner was catching on a
+    // fast second click.
+    const FAN: NodeData[] = [
+      { id: 'a' },
+      { id: 'b1', parentId: 'a' },
+      { id: 'b2', parentId: 'a' },
+      { id: 'b3', parentId: 'a' },
+    ]
+    const renderer = fakeRenderer()
+    const engine = createChartEngine(renderer)
+    const tree = normalize(FAN)
+    engine.setAnimate(true)
+    engine.setViewport(800, 600, 1)
+    engine.setCamera({ x: 0, y: 0, k: 1 })
+    const open = new Uint8Array(tree.count).fill(0)
+    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'b1', 'b2', 'b3'], open)
+    engine.render(1000)
+
+    engine.setOpen(tree.idToIndex.get('a')!, true)
+    engine.render(2000)
+    // Well into the reveal, but not finished: 'b1' is part-grown.
+    engine.render(2000 + TRANSITION_MS * 0.75)
+    const b1Idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('b1')!)
+    const midWidth = renderer.frames.at(-1)!.boxes[b1Idx * 4 + 2]!
+    const finalWidth = engine.boxes[b1Idx * 4 + 2]!
+    expect(midWidth).toBeGreaterThan(0)
+    expect(midWidth).toBeLessThan(finalWidth * 0.95) // genuinely still growing
+
+    // The interrupting toggle. 'b1' leaves the tree, so it carries on as a
+    // ghost — and the ghost has to start at the size it was just drawn at.
+    engine.setOpen(tree.idToIndex.get('a')!, false)
+    engine.render(2000 + TRANSITION_MS * 0.75)
+    const frame = renderer.frames.at(-1)!
+    expect(frame.ghostCount).toBeGreaterThan(0)
+
+    let widest = 0
+    for (let g = 0; g < frame.ghostCount; g++) widest = Math.max(widest, frame.ghostBoxes[g * 4 + 2]!)
+    // Within a hair of where it was, and nowhere near the full-size jump.
+    expect(widest).toBeCloseTo(midWidth, 1)
+    expect(widest).toBeLessThan(finalWidth * 0.95)
+  })
+
   it("grows a grandchild out of its OWN parent's exit point, not the toggled node's", () => {
     // Expanding 'a' reveals 'p' AND 'q' in one transition, because 'p' was
     // left open when it went out of view — the ordinary case, since open

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -885,100 +885,81 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(early.ghostAlpha[0]).toBeLessThan(0.3)
   })
 
-  it("grows a revealed node from its anchor's LIVE position, not the anchor's fixed pre-toggle box", () => {
-    // 'p' needs TWO children, not one — see the analogous sibling-reflow test
-    // in packages/core's orgchart.browser.test.ts for why: a single-child
-    // chain never widens its own subtree, so 'p' itself never needs to
-    // recentre. Two children side by side make 'p' noticeably wider once
-    // revealed, which is exactly what pushes 'p's OWN box, not just its
-    // sibling's, away from its pre-toggle position.
-    const NESTED: NodeData[] = [
-      { id: 'a' },
-      { id: 'p', parentId: 'a' },
-      { id: 'q1', parentId: 'p' },
-      { id: 'q2', parentId: 'p' },
-      { id: 'b', parentId: 'a' },
-    ]
+  it('unfolds a grandchild out of its OWN parent, live, as that parent is still unfolding', () => {
+    // Two things at once, both of them the owner's: a revealed node grows out
+    // of its own parent rather than the nearest ancestor that happened to
+    // already have a position ("they can even come out from higher up"), and
+    // it reads that parent's position LIVE rather than from a snapshot.
+    //
+    // Expanding 'a' reveals 'p' AND 'q' in one transition, because 'p' was
+    // left open when it went out of view — the ordinary case, since open
+    // state is remembered. 'p' has no prior position of its own, so the old
+    // walk-up-the-chain rule sent 'q' to grow from 'a', a whole row above
+    // where it belongs. It should grow from 'p', which is at that moment
+    // somewhere between 'a's bottom edge and its own settled row.
+    const CHAIN: NodeData[] = [{ id: 'a' }, { id: 'p', parentId: 'a' }, { id: 'q', parentId: 'p' }]
     const renderer = fakeRenderer()
     const engine = createChartEngine(renderer)
-    const tree = normalize(NESTED)
+    const tree = normalize(CHAIN)
     engine.setAnimate(true)
     engine.setViewport(800, 600, 1)
     engine.setCamera({ x: 0, y: 0, k: 1 })
     const open = new Uint8Array(tree.count).fill(1)
-    open[tree.idToIndex.get('p')!] = 0 // start collapsed: 'q1'/'q2' hidden
-    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'p', 'q1', 'q2', 'b'], open)
-    engine.render(1000) // settle the collapsed layout — no transition, the first layout
+    open[tree.idToIndex.get('a')!] = 0 // 'a' shut: neither 'p' nor 'q' is on screen
+    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'p', 'q'], open)
+    engine.render(1000)
 
-    // Reads 'p's/'q1's AUTHORITATIVE (final, settled) box — unaffected by
-    // any in-progress transition, which only interpolates the DRAWN frame,
-    // never `engine.boxes` itself.
-    const finalBoxOf = (id: string): { x: number; y: number; w: number } => {
-      const src = tree.idToIndex.get(id)!
-      const idx = Array.from(engine.visibleToSource).indexOf(src)
-      expect(idx).toBeGreaterThanOrEqual(0)
-      const o = idx * 4
-      return { x: engine.boxes[o]!, y: engine.boxes[o + 1]!, w: engine.boxes[o + 2]! }
-    }
-    // Reads 'id's DRAWN (interpolated) box off the most recent frame —
-    // where it actually is on screen at that instant, unlike `finalBoxOf`.
-    const drawnBoxOf = (id: string): { x: number; y: number; w: number } => {
-      const src = tree.idToIndex.get(id)!
-      const idx = Array.from(engine.visibleToSource).indexOf(src)
+    const drawn = (id: string) => {
+      const idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get(id)!)
       expect(idx).toBeGreaterThanOrEqual(0)
       const frame = renderer.frames.at(-1)!
-      const o = idx * 4
-      return { x: frame.boxes[o]!, y: frame.boxes[o + 1]!, w: frame.boxes[o + 2]! }
+      return { y: frame.boxes[idx * 4 + 1]!, h: frame.boxes[idx * 4 + 3]! }
     }
-    // 'p's own reveal-anchor EXIT point, x-axis only: for the default 'tb'
-    // orientation this test runs under, a revealed child's growth-start
-    // point is 'p's BOTTOM-edge, HORIZONTAL centre (see engine.ts's
-    // `exitBox`/`exitPointXY`) — i.e. `x + w/2`, not the box's raw top-left
-    // `x` a reveal used to grow from before that fix.
-    const exitX = (box: { x: number; w: number }): number => box.x + box.w / 2
+    const settled = (id: string) => {
+      const idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get(id)!)
+      return { y: engine.boxes[idx * 4 + 1]!, h: engine.boxes[idx * 4 + 3]! }
+    }
 
-    const pBefore = finalBoxOf('p') // 'p's box while still collapsed
+    engine.setOpen(tree.idToIndex.get('a')!, true) // reveals 'p' and 'q' together
+    engine.render(2000)
 
-    engine.setOpen(tree.idToIndex.get('p')!, true) // reveals q1/q2, recentring 'p'
-    engine.render(2000) // t=0 of the new transition
-    const pAfter = finalBoxOf('p') // 'p's NEW (final, post-relayout) box
+    // Partway through phase 2 (the reveal), so 'p' is mid-unfold: its bottom
+    // edge is below 'a's and above where it will settle.
+    engine.render(2000 + TRANSITION_MS * 0.7)
+    const a = drawn('a')
+    const pLive = drawn('p')
+    const pSettled = settled('p')
+    const q = drawn('q')
 
-    // Sanity: the scenario this test exists to exercise. If 'p' didn't
-    // actually move between the two layouts, the discriminating assertion
-    // below would pass no matter which anchor box `render()` used.
-    expect(Math.abs(exitX(pAfter) - exitX(pBefore))).toBeGreaterThan(5)
+    const pLiveBottom = pLive.y + pLive.h
+    expect(pLiveBottom).toBeGreaterThan(a.y + a.h)
+    expect(pLiveBottom).toBeLessThan(pSettled.y + pSettled.h)
 
-    // Overall progress 0.5 (half of `TRANSITION_MS`): for an EXPAND,
-    // `repositionRaw` (driving 'p's own reposition tween) is `phaseOneProgress`,
-    // three quarters done by this point (phase 1 spans the first ~67%) — 'p' is
-    // most of the way to `pAfter`. `emphasisRaw` (driving 'q1's reveal) is
-    // `phaseTwoProgress`, a quarter in (phase 2 starts around 33%) and eased,
-    // so 'q1' has barely left its growth-start point. So 'q1's rendered box
-    // should sit almost exactly on 'p's LIVE exit point (~exitX(pAfter)), not
-    // on 'p's stale pre-toggle exit point (exitX(pBefore)) — and the two are
-    // far enough apart (asserted above) that the bug this test guards
-    // against — growing from a fixed snapshot instead of the anchor's
-    // current position — would be unmistakable here.
-    engine.render(2000 + TRANSITION_MS / 2)
-    const pLive = drawnBoxOf('p')
-    const q1Rendered = drawnBoxOf('q1')
+    // Both 'p' and 'q' ride the same reveal curve, so how far along it is can
+    // be read straight off 'p': its height runs 0 -> settled by exactly that
+    // fraction. That makes the expected position of 'q' an equation rather
+    // than a range — and one the two rules answer differently.
+    const progress = pLive.h / pSettled.h
+    expect(progress).toBeGreaterThan(0.1)
+    expect(progress).toBeLessThan(0.9)
+    const qSettledTop = settled('q').y
+    const fromOwnParent = pLiveBottom + (qSettledTop - pLiveBottom) * progress
+    const fromToggledNode = a.y + a.h + (qSettledTop - (a.y + a.h)) * progress
 
-    const distanceFromLiveAnchor = Math.abs(q1Rendered.x - exitX(pLive))
-    const distanceFromStaleAnchor = Math.abs(q1Rendered.x - exitX(pBefore))
-    expect(distanceFromLiveAnchor).toBeLessThan(distanceFromStaleAnchor)
-    // 'q1' should be reading as still close to wherever 'p's exit point
-    // actually is, not merely "closer to live than to stale by some margin"
-    // while still far from both.
-    expect(distanceFromLiveAnchor).toBeLessThan(Math.abs(exitX(pAfter) - exitX(pBefore)) / 2)
+    expect(q.y).toBeCloseTo(fromOwnParent, 6)
+    // Not a distinction without a difference: the two are a visible distance
+    // apart, which is exactly the gap the owner was seeing.
+    expect(Math.abs(fromOwnParent - fromToggledNode)).toBeGreaterThan(10)
   })
 
-  it("grows a revealed child from the PARENT's exit edge (bottom-centre for tb), not its box origin/centre", () => {
-    // The owner's ask for task 2: children should visibly drop out of the
-    // bottom of the parent node, not balloon out of its middle. Single
-    // child, single parent, single root — nothing here recentres 'p' itself
-    // (unlike the LIVE-vs-STALE test above, which deliberately needs that),
-    // isolating just the growth-start POINT this test cares about.
-    const SIMPLE: NodeData[] = [{ id: 'a' }, { id: 'q', parentId: 'a' }]
+  it("unfolds a revealed child from directly under the PARENT, in the child's own column", () => {
+    // The owner's ask, twice over: the reveal must not start "in the middle"
+    // of the parent, it must start "just underneath" it. So the growth-start
+    // box is flat against the parent's bottom edge — zero height, the fold
+    // line — but already at the child's OWN x and width, rather than a single
+    // point at the parent's centre that a whole row of children would then
+    // fan out from. See `growthBox` in engine.ts.
+    const SIMPLE: NodeData[] = [{ id: 'a' }, { id: 'q', parentId: 'a' }, { id: 'r', parentId: 'a' }]
     const renderer = fakeRenderer()
     const engine = createChartEngine(renderer)
     const tree = normalize(SIMPLE)
@@ -986,7 +967,7 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.setViewport(800, 600, 1)
     engine.setCamera({ x: 0, y: 0, k: 1 })
     const open = new Uint8Array(tree.count).fill(0) // 'a' starts collapsed
-    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'q'], open)
+    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'q', 'r'], open)
     engine.render(1000)
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
@@ -998,20 +979,35 @@ describe('ChartEngine expand/collapse transition', () => {
     }
 
     engine.setOpen(tree.idToIndex.get('a')!, true)
-    engine.render(2000) // t=0 of the transition: 'q' is at its growth-start point exactly
+    engine.render(2000) // t=0 of the transition: both children sit exactly on their fold line
     const frame = renderer.frames.at(-1)!
-    const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
-    const qStart = { x: frame.boxes[qIdx * 4]!, y: frame.boxes[qIdx * 4 + 1]! }
 
-    // Bottom edge, horizontal centre of 'a' — NOT 'a's top-left corner (the
-    // old, wrong growth-start point) and not 'a's own centre either.
-    expect(qStart.x).toBeCloseTo(aBox.x + aBox.w / 2, 6)
-    expect(qStart.y).toBeCloseTo(aBox.y + aBox.h, 6)
-    // A genuine POINT, not sized like the parent — confirms this grows from
-    // a single spot and expands outward, rather than starting already
-    // shaped like the whole parent box.
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
+    for (const id of ['q', 'r']) {
+      const idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get(id)!)
+      const start = {
+        x: frame.boxes[idx * 4]!,
+        y: frame.boxes[idx * 4 + 1]!,
+        w: frame.boxes[idx * 4 + 2]!,
+        h: frame.boxes[idx * 4 + 3]!,
+      }
+      const settled = { x: engine.boxes[idx * 4]!, w: engine.boxes[idx * 4 + 2]! }
+
+      // Under the parent's bottom edge, and flat against it.
+      expect(start.y).toBeCloseTo(aBox.y + aBox.h, 6)
+      expect(start.h).toBeCloseTo(0, 6)
+      // ...but already in its own column, at its own width — NOT collapsed
+      // onto the parent's horizontal centre.
+      expect(start.x).toBeCloseTo(settled.x, 6)
+      expect(start.w).toBeCloseTo(settled.w, 6)
+    }
+
+    // The two children start apart, which is the whole point: the old
+    // behaviour put both on the same point under the middle of 'a'.
+    const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
+    const rIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('r')!)
+    expect(Math.abs(frame.boxes[qIdx * 4]! - frame.boxes[rIdx * 4]!)).toBeGreaterThan(50)
+    // ...and neither of them is the parent's centre.
+    expect(Math.abs(frame.boxes[qIdx * 4]! - (aBox.x + aBox.w / 2))).toBeGreaterThan(1)
   })
 
   it("shrinks a collapsing ghost back into the PARENT's exit edge, not its box origin/centre", () => {
@@ -1027,6 +1023,7 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, false) // collapse: 'q' becomes a ghost
     engine.render(1000)
+    const ghostStartX = renderer.frames.at(-1)!.ghostBoxes[0]!
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
     const aBoxNow = {
@@ -1036,14 +1033,27 @@ describe('ChartEngine expand/collapse transition', () => {
       h: engine.boxes[aIdx * 4 + 3]!,
     }
 
+    // Where the ghost started, so the column assertion below has something
+    // to be true OF: it folds away in the place it occupied, not into a
+    // point under the middle of its parent.
+    const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
+    const qWasX = qIdx === -1 ? null : engine.boxes[qIdx * 4]!
+
     // Right at the end of the transition (but still just inside it): the
-    // ghost has nearly finished shrinking toward its target, so its drawn
-    // box should sit almost exactly on 'a's exit point.
+    // ghost has nearly finished folding away, so its drawn box should sit
+    // almost exactly on its target.
     engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
-    expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
+    // Flat against 'a's bottom edge...
     expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h, 1)
+    expect(frame.ghostBoxes[3]).toBeCloseTo(0, 1)
+    // ...in its own column, keeping the width it had. `qWasX` is `null` only
+    // if 'q' had already left the pruned tree, which is the case here — it
+    // is a ghost — so the check is against the ghost's own starting x, which
+    // is where a collapse leaves it.
+    expect(frame.ghostBoxes[0]).toBeCloseTo(ghostStartX, 1)
+    expect(qWasX).toBeNull()
   })
 
   it("grows a revealed child from the parent's TRAILING edge under lr orientation, not its bottom edge", () => {
@@ -1077,10 +1087,15 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
-    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6) // right edge
-    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(aBox.y + aBox.h / 2, 6) // vertical centre
+    // Flat against 'a's trailing (right) edge, zero width...
+    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6)
     expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
+    // ...and already in its own ROW, at its own height: the growth axis is x
+    // here, so it is y that keeps what the child will settle with — the
+    // mirror of what the tb case asserts about x. Not 'a's vertical centre,
+    // which is where a single-point growth start would have put it.
+    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(engine.boxes[qIdx * 4 + 1]!, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
   })
 
   it('a second toggle mid-transition retargets from the current position instead of snapping', () => {

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -46,6 +46,14 @@ function fakeRenderer(): Renderer & { frames: Frame[] } {
   }
 }
 
+/**
+ * Mirrors `TRANSITION_DURATION_MS` in engine.ts, which is not exported: the
+ * phase lengths there are tuned by eye and have moved before, so every test
+ * that has to sit at a specific point INSIDE the transition (rather than
+ * comfortably past its end) says it through this one constant.
+ */
+const TRANSITION_MS = 390
+
 const DATA = [{ id: 'a' }, { id: 'b', parentId: 'a' }, { id: 'c', parentId: 'b' }, { id: 'd', parentId: 'a' }]
 
 function sizesFor(count: number, w = 100, h = 50): Float64Array {
@@ -817,7 +825,7 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.render(1000)
     expect(engine.transitioning).toBe(true)
 
-    engine.render(1450) // exactly the 450ms total duration (two staged phases): progress 1
+    engine.render(1000 + TRANSITION_MS) // exactly the total duration (two staged phases): progress 1
     expect(engine.transitioning).toBe(false)
     const frame = renderer.frames.at(-1)!
     expect(Array.from(frame.boxes)).toEqual(Array.from(engine.boxes))
@@ -861,10 +869,9 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.setOpen(tree.idToIndex.get('b')!, false) // removes 'c'
     engine.render(1000) // t=0: just started, still ~opaque (asserted elsewhere)
 
-    // 450ms is the transition's total duration (TRANSITION_DURATION_MS) —
-    // same constant the sibling ghost test above pins by hand. The midpoint
-    // is 225ms in.
-    engine.render(1000 + 225)
+    // `TRANSITION_MS` is the transition's total duration — the same constant
+    // the sibling ghost test above works from. The midpoint is half of it.
+    engine.render(1000 + TRANSITION_MS / 2)
     const atMidpoint = renderer.frames.at(-1)!
     expect(atMidpoint.ghostCount).toBe(1)
     expect(atMidpoint.ghostAlpha[0]).toBeLessThan(0.05) // already gone well before the midpoint
@@ -941,18 +948,18 @@ describe('ChartEngine expand/collapse transition', () => {
     // below would pass no matter which anchor box `render()` used.
     expect(Math.abs(exitX(pAfter) - exitX(pBefore))).toBeGreaterThan(5)
 
-    // Overall progress 0.5 (225ms of the 450ms total): for an EXPAND,
+    // Overall progress 0.5 (half of `TRANSITION_MS`): for an EXPAND,
     // `repositionRaw` (driving 'p's own reposition tween) is `phaseOneProgress`,
-    // ~99% done by this point (phase 1 spans roughly the first 58%) — 'p' is
-    // nearly at `pAfter`. `emphasisRaw` (driving 'q1's reveal) is
-    // `phaseTwoProgress`, only ~1% in (phase 2 starts around 42%) — 'q1' has
-    // barely left its growth-start point. So 'q1's rendered box right now
+    // three quarters done by this point (phase 1 spans the first ~67%) — 'p' is
+    // most of the way to `pAfter`. `emphasisRaw` (driving 'q1's reveal) is
+    // `phaseTwoProgress`, a quarter in (phase 2 starts around 33%) and eased,
+    // so 'q1' has barely left its growth-start point. So 'q1's rendered box
     // should sit almost exactly on 'p's LIVE exit point (~exitX(pAfter)), not
     // on 'p's stale pre-toggle exit point (exitX(pBefore)) — and the two are
     // far enough apart (asserted above) that the bug this test guards
     // against — growing from a fixed snapshot instead of the anchor's
     // current position — would be unmistakable here.
-    engine.render(2000 + 225)
+    engine.render(2000 + TRANSITION_MS / 2)
     const pLive = drawnBoxOf('p')
     const q1Rendered = drawnBoxOf('q1')
 
@@ -1032,7 +1039,7 @@ describe('ChartEngine expand/collapse transition', () => {
     // Right at the end of the transition (but still just inside it): the
     // ghost has nearly finished shrinking toward its target, so its drawn
     // box should sit almost exactly on 'a's exit point.
-    engine.render(1000 + 449)
+    engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
     expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
@@ -1311,7 +1318,7 @@ describe('ChartEngine expand/collapse transition', () => {
       survivorSources: number[],
       transitionStart: number,
     ): void {
-      const checkpoints = [0, 0.15, 0.3, 0.5, 0.7, 0.85, 0.99].map((f) => transitionStart + f * 450)
+      const checkpoints = [0, 0.15, 0.3, 0.5, 0.7, 0.85, 0.99].map((f) => transitionStart + f * TRANSITION_MS)
       for (const t of checkpoints) {
         engine.render(t)
         const frame = renderer.frames.at(-1)!
@@ -1593,7 +1600,7 @@ describe('ChartEngine one-shot toggle ring', () => {
 
   it('keeps `engine.ringActive` true after `transitioning` has already gone false', () => {
     // RING_DURATION_MS (900ms) deliberately outlives TRANSITION_DURATION_MS
-    // (450ms, see engine.ts) so the ring is still resolving well after the
+    // (`TRANSITION_MS` here, see engine.ts) so the ring is still resolving after the
     // layout transition settles. A caller driving its own frame loop off only
     // `transitioning` — as the vanilla layer's `scheduleFrame` briefly did —
     // stops asking for frames the instant the transition ends and freezes
@@ -1611,7 +1618,7 @@ describe('ChartEngine one-shot toggle ring', () => {
     expect(engine.transitioning).toBe(true)
     expect(engine.ringActive).toBe(true)
 
-    engine.render(1500) // past the 450ms transition, still well inside the 900ms ring
+    engine.render(1500) // past the layout transition, still well inside the 900ms ring
     expect(engine.transitioning).toBe(false)
     expect(engine.ringActive).toBe(true)
 
@@ -1744,7 +1751,7 @@ describe('block-tier decimation in render()', () => {
     engine.setOpen(child, false)
     const duringTransition = engine.render(1).length
 
-    // Once the transition has run its course (TRANSITION_DURATION_MS ~450ms),
+    // Once the transition has run its course (TRANSITION_DURATION_MS, see engine.ts),
     // the engine falls back to the steady state and — blockDecimation still
     // being on — decimation kicks back in at this same post-toggle camera.
     // A `during` count that is NOT smaller than this settled, decimated count

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -984,17 +984,20 @@ describe('ChartEngine expand/collapse transition', () => {
     const pLive = drawn('p')
     const q = drawn('q')
 
-    // Both ride the same reveal curve, so how far along it is reads straight
-    // off 'p': it travels from its own start (one mark below 'a') to its row
-    // by exactly that fraction. That makes the expected position of 'q' an
-    // equation, and the two rules answer it differently.
-    const pStart = a.y + a.h + REVEAL_REACH
-    const progress = (pLive.y - pStart) / (settled('p').y - pStart)
+    // Both ride the same reveal curve, and a reveal grows out of a POINT, so
+    // how far along it is reads straight off 'p': its height runs 0 ->
+    // settled by exactly that fraction. That makes the expected position of
+    // 'q' an equation, and the two rules answer it differently.
+    const progress = pLive.h / settled('p').h
     expect(progress).toBeGreaterThan(0.1)
     expect(progress).toBeLessThan(0.9)
+    // 'p' is itself arriving, so it has no meaningful current position to
+    // offer: the point 'q' grows out of is where 'p's mark WILL be, not where
+    // its part-grown box is this instant. See `anchorBoxFor`.
     const qSettledTop = settled('q').y
-    const pOrigin = pLive.y + pLive.h + REVEAL_REACH
-    const aOrigin = pStart
+    const pSettled = settled('p')
+    const pOrigin = pSettled.y + pSettled.h + REVEAL_REACH
+    const aOrigin = a.y + a.h + REVEAL_REACH
     const fromOwnParent = pOrigin + (qSettledTop - pOrigin) * progress
     const fromToggledNode = aOrigin + (qSettledTop - aOrigin) * progress
 
@@ -1035,15 +1038,15 @@ describe('ChartEngine expand/collapse transition', () => {
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
     const qStart = { x: frame.boxes[qIdx * 4]!, y: frame.boxes[qIdx * 4 + 1]! }
 
-    // Just past the tip of the mark hanging off 'a's bottom edge...
+    // A POINT, at the horizontal centre of 'a' and just past the tip of the
+    // mark hanging off its bottom edge — so the child scales up out of that
+    // tip, outwards in both directions and downwards, which is the owner's
+    // ask in their own words. Its centre travels from the tip to its own
+    // settled centre, which is what `lerpBox` from a zero-size box does.
+    expect(qStart.x).toBeCloseTo(aBox.x + aBox.w / 2, 6)
     expect(qStart.y).toBeCloseTo(aBox.y + aBox.h + REVEAL_REACH, 6)
-    // ...at its own size and in its own column. We know what size it is going
-    // to be, so it starts that size: growing it out of nothing put its
-    // top-left corner on the start point and left the card looking like it
-    // came out of that corner.
-    expect(frame.boxes[qIdx * 4]).toBeCloseTo(engine.boxes[qIdx * 4]!, 6)
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
   })
 
   it("shrinks a collapsing ghost back into the PARENT's exit edge, not its box origin/centre", () => {
@@ -1059,10 +1062,6 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, false) // collapse: 'q' becomes a ghost
     engine.render(1000)
-    // The size it leaves with, kept for the whole fold-away: a ghost slides
-    // back behind the mark rather than shrinking into it.
-    const ghostHeight = renderer.frames.at(-1)!.ghostBoxes[3]!
-
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
     const aBoxNow = {
       x: engine.boxes[aIdx * 4]!,
@@ -1072,13 +1071,13 @@ describe('ChartEngine expand/collapse transition', () => {
     }
 
     // Right at the end of the transition (but still just inside it): the
-    // ghost has nearly finished folding away, so its drawn box should sit
-    // almost exactly on its target — one mark's length below 'a'.
+    // ghost has nearly finished shrinking into its target, so its drawn box
+    // should sit almost exactly on it — the tip of 'a's mark.
     engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
+    expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
     expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h + REVEAL_REACH, 1)
-    expect(frame.ghostBoxes[3]).toBeCloseTo(ghostHeight, 1)
   })
 
   it("grows a revealed child from the parent's TRAILING edge under lr orientation, not its bottom edge", () => {
@@ -1113,11 +1112,9 @@ describe('ChartEngine expand/collapse transition', () => {
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
     expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w + REVEAL_REACH, 6) // past the mark
-    // Its own row and its own size — the growth axis is x here, so it is y
-    // that keeps what the child settles with.
-    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(engine.boxes[qIdx * 4 + 1]!, 6)
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
+    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(aBox.y + aBox.h / 2, 6) // vertical centre
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
   })
 
   it('a second toggle mid-transition retargets from the current position instead of snapping', () => {

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createChartEngine } from './engine.js'
 import { toWireTree, wireTreeToTree } from './worker/protocol.js'
 import { normalize } from './tree.js'
+import { HIDDEN_DOT_PX, HIDDEN_STUB_PX } from './render/edge-geometry.js'
 import { fit } from './viewport.js'
 import { gridSizeFor } from './render/decimate.js'
 import type { Frame, Renderer } from './render/renderer.js'
@@ -53,6 +54,13 @@ function fakeRenderer(): Renderer & { frames: Frame[] } {
  * comfortably past its end) says it through this one constant.
  */
 const TRANSITION_MS = 390
+
+/**
+ * How far past the node's exit edge a reveal starts — the "more inside" mark's
+ * own length plus its dot, in world units at `k = 1` (which is what every test
+ * here renders at). See `revealOrigin` in engine.ts.
+ */
+const REVEAL_REACH = HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2
 
 const DATA = [{ id: 'a' }, { id: 'b', parentId: 'a' }, { id: 'c', parentId: 'b' }, { id: 'd', parentId: 'a' }]
 
@@ -1072,9 +1080,10 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(progress).toBeGreaterThan(0.1)
     expect(progress).toBeLessThan(0.9)
     const qSettledTop = settled('q').y
-    const pLiveBottom = pLive.y + pLive.h
-    const fromOwnParent = pLiveBottom + (qSettledTop - pLiveBottom) * progress
-    const fromToggledNode = a.y + a.h + (qSettledTop - (a.y + a.h)) * progress
+    const pOrigin = pLive.y + pLive.h + REVEAL_REACH
+    const aOrigin = a.y + a.h + REVEAL_REACH
+    const fromOwnParent = pOrigin + (qSettledTop - pOrigin) * progress
+    const fromToggledNode = aOrigin + (qSettledTop - aOrigin) * progress
 
     expect(q.y).toBeCloseTo(fromOwnParent, 6)
     // Not a distinction without a difference: a visible distance apart, which
@@ -1113,10 +1122,11 @@ describe('ChartEngine expand/collapse transition', () => {
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
     const qStart = { x: frame.boxes[qIdx * 4]!, y: frame.boxes[qIdx * 4 + 1]! }
 
-    // Bottom edge, horizontal centre of 'a' — NOT 'a's top-left corner (the
-    // old, wrong growth-start point) and not 'a's own centre either.
+    // Horizontal centre of 'a', and just past the tip of the mark hanging off
+    // its bottom edge — NOT 'a's top-left corner (the old, wrong growth-start
+    // point), not its centre, and not flush against its underside either.
     expect(qStart.x).toBeCloseTo(aBox.x + aBox.w / 2, 6)
-    expect(qStart.y).toBeCloseTo(aBox.y + aBox.h, 6)
+    expect(qStart.y).toBeCloseTo(aBox.y + aBox.h + REVEAL_REACH, 6)
     // A genuine POINT, not sized like the parent — confirms this grows from
     // a single spot and expands outward, rather than starting already
     // shaped like the whole parent box.
@@ -1153,7 +1163,7 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
     expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
-    expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h, 1)
+    expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h + REVEAL_REACH, 1)
   })
 
   it("grows a revealed child from the parent's TRAILING edge under lr orientation, not its bottom edge", () => {
@@ -1187,7 +1197,7 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
-    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6) // right edge
+    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w + REVEAL_REACH, 6) // past the mark
     expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(aBox.y + aBox.h / 2, 6) // vertical centre
     expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
     expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -885,18 +885,106 @@ describe('ChartEngine expand/collapse transition', () => {
     expect(early.ghostAlpha[0]).toBeLessThan(0.3)
   })
 
-  it('unfolds a grandchild out of its OWN parent, live, as that parent is still unfolding', () => {
-    // Two things at once, both of them the owner's: a revealed node grows out
-    // of its own parent rather than the nearest ancestor that happened to
-    // already have a position ("they can even come out from higher up"), and
-    // it reads that parent's position LIVE rather than from a snapshot.
-    //
+  it("grows a revealed node from its anchor's LIVE position, not the anchor's fixed pre-toggle box", () => {
+    // 'p' needs TWO children, not one — see the analogous sibling-reflow test
+    // in packages/core's orgchart.browser.test.ts for why: a single-child
+    // chain never widens its own subtree, so 'p' itself never needs to
+    // recentre. Two children side by side make 'p' noticeably wider once
+    // revealed, which is exactly what pushes 'p's OWN box, not just its
+    // sibling's, away from its pre-toggle position.
+    const NESTED: NodeData[] = [
+      { id: 'a' },
+      { id: 'p', parentId: 'a' },
+      { id: 'q1', parentId: 'p' },
+      { id: 'q2', parentId: 'p' },
+      { id: 'b', parentId: 'a' },
+    ]
+    const renderer = fakeRenderer()
+    const engine = createChartEngine(renderer)
+    const tree = normalize(NESTED)
+    engine.setAnimate(true)
+    engine.setViewport(800, 600, 1)
+    engine.setCamera({ x: 0, y: 0, k: 1 })
+    const open = new Uint8Array(tree.count).fill(1)
+    open[tree.idToIndex.get('p')!] = 0 // start collapsed: 'q1'/'q2' hidden
+    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'p', 'q1', 'q2', 'b'], open)
+    engine.render(1000) // settle the collapsed layout — no transition, the first layout
+
+    // Reads 'p's/'q1's AUTHORITATIVE (final, settled) box — unaffected by
+    // any in-progress transition, which only interpolates the DRAWN frame,
+    // never `engine.boxes` itself.
+    const finalBoxOf = (id: string): { x: number; y: number; w: number } => {
+      const src = tree.idToIndex.get(id)!
+      const idx = Array.from(engine.visibleToSource).indexOf(src)
+      expect(idx).toBeGreaterThanOrEqual(0)
+      const o = idx * 4
+      return { x: engine.boxes[o]!, y: engine.boxes[o + 1]!, w: engine.boxes[o + 2]! }
+    }
+    // Reads 'id's DRAWN (interpolated) box off the most recent frame —
+    // where it actually is on screen at that instant, unlike `finalBoxOf`.
+    const drawnBoxOf = (id: string): { x: number; y: number; w: number } => {
+      const src = tree.idToIndex.get(id)!
+      const idx = Array.from(engine.visibleToSource).indexOf(src)
+      expect(idx).toBeGreaterThanOrEqual(0)
+      const frame = renderer.frames.at(-1)!
+      const o = idx * 4
+      return { x: frame.boxes[o]!, y: frame.boxes[o + 1]!, w: frame.boxes[o + 2]! }
+    }
+    // 'p's own reveal-anchor EXIT point, x-axis only: for the default 'tb'
+    // orientation this test runs under, a revealed child's growth-start
+    // point is 'p's BOTTOM-edge, HORIZONTAL centre (see engine.ts's
+    // `exitBox`/`exitPointXY`) — i.e. `x + w/2`, not the box's raw top-left
+    // `x` a reveal used to grow from before that fix.
+    const exitX = (box: { x: number; w: number }): number => box.x + box.w / 2
+
+    const pBefore = finalBoxOf('p') // 'p's box while still collapsed
+
+    engine.setOpen(tree.idToIndex.get('p')!, true) // reveals q1/q2, recentring 'p'
+    engine.render(2000) // t=0 of the new transition
+    const pAfter = finalBoxOf('p') // 'p's NEW (final, post-relayout) box
+
+    // Sanity: the scenario this test exists to exercise. If 'p' didn't
+    // actually move between the two layouts, the discriminating assertion
+    // below would pass no matter which anchor box `render()` used.
+    expect(Math.abs(exitX(pAfter) - exitX(pBefore))).toBeGreaterThan(5)
+
+    // Overall progress 0.5 (half of `TRANSITION_MS`): for an EXPAND,
+    // `repositionRaw` (driving 'p's own reposition tween) is `phaseOneProgress`,
+    // three quarters done by this point (phase 1 spans the first ~67%) — 'p' is
+    // most of the way to `pAfter`. `emphasisRaw` (driving 'q1's reveal) is
+    // `phaseTwoProgress`, a quarter in (phase 2 starts around 33%) and eased,
+    // so 'q1' has barely left its growth-start point. So 'q1's rendered box
+    // should sit almost exactly on 'p's LIVE exit point (~exitX(pAfter)), not
+    // on 'p's stale pre-toggle exit point (exitX(pBefore)) — and the two are
+    // far enough apart (asserted above) that the bug this test guards
+    // against — growing from a fixed snapshot instead of the anchor's
+    // current position — would be unmistakable here.
+    engine.render(2000 + TRANSITION_MS / 2)
+    const pLive = drawnBoxOf('p')
+    const q1Rendered = drawnBoxOf('q1')
+
+    const distanceFromLiveAnchor = Math.abs(q1Rendered.x - exitX(pLive))
+    const distanceFromStaleAnchor = Math.abs(q1Rendered.x - exitX(pBefore))
+    expect(distanceFromLiveAnchor).toBeLessThan(distanceFromStaleAnchor)
+    // 'q1' should be reading as still close to wherever 'p's exit point
+    // actually is, not merely "closer to live than to stale by some margin"
+    // while still far from both.
+    expect(distanceFromLiveAnchor).toBeLessThan(Math.abs(exitX(pAfter) - exitX(pBefore)) / 2)
+  })
+
+  it("grows a grandchild out of its OWN parent's exit point, not the toggled node's", () => {
     // Expanding 'a' reveals 'p' AND 'q' in one transition, because 'p' was
     // left open when it went out of view — the ordinary case, since open
-    // state is remembered. 'p' has no prior position of its own, so the old
-    // walk-up-the-chain rule sent 'q' to grow from 'a', a whole row above
-    // where it belongs. It should grow from 'p', which is at that moment
-    // somewhere between 'a's bottom edge and its own settled row.
+    // state is remembered. Neither has a prior position, and the anchor rule
+    // used to walk UP past 'p' to the nearest node that had one, which is
+    // 'a': so 'q' grew out of 'a's bottom edge, a whole row above where it
+    // belongs, while its own parent grew somewhere else entirely. The owner
+    // watching a branch open: "they can even come out from higher up."
+    //
+    // 'q' has to grow out of 'p', at whatever point 'p' has reached — 'p' is
+    // itself still on its way out of 'a' at that instant, and `applyTween`
+    // resolves an anchor before whatever hangs off it, so a live box for it
+    // always exists.
     const CHAIN: NodeData[] = [{ id: 'a' }, { id: 'p', parentId: 'a' }, { id: 'q', parentId: 'p' }]
     const renderer = fakeRenderer()
     const engine = createChartEngine(renderer)
@@ -922,45 +1010,38 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, true) // reveals 'p' and 'q' together
     engine.render(2000)
+    engine.render(2000 + TRANSITION_MS * 0.7) // partway into the reveal phase
 
-    // Partway through phase 2 (the reveal), so 'p' is mid-unfold: its bottom
-    // edge is below 'a's and above where it will settle.
-    engine.render(2000 + TRANSITION_MS * 0.7)
     const a = drawn('a')
     const pLive = drawn('p')
-    const pSettled = settled('p')
     const q = drawn('q')
 
-    const pLiveBottom = pLive.y + pLive.h
-    expect(pLiveBottom).toBeGreaterThan(a.y + a.h)
-    expect(pLiveBottom).toBeLessThan(pSettled.y + pSettled.h)
-
-    // Both 'p' and 'q' ride the same reveal curve, so how far along it is can
-    // be read straight off 'p': it slides from 'a's bottom edge to its own
-    // row by exactly that fraction. That makes the expected position of 'q'
-    // an equation rather than a range — and one the two rules answer
+    // Both ride the same reveal curve, and a revealed node grows out of a
+    // POINT, so how far along that curve is reads straight off 'p': its
+    // height runs 0 -> settled by exactly that fraction. That makes the
+    // expected position of 'q' an equation, and the two rules answer it
     // differently.
-    const progress = (pLive.y - (a.y + a.h)) / (pSettled.y - (a.y + a.h))
+    const progress = pLive.h / settled('p').h
     expect(progress).toBeGreaterThan(0.1)
     expect(progress).toBeLessThan(0.9)
     const qSettledTop = settled('q').y
+    const pLiveBottom = pLive.y + pLive.h
     const fromOwnParent = pLiveBottom + (qSettledTop - pLiveBottom) * progress
     const fromToggledNode = a.y + a.h + (qSettledTop - (a.y + a.h)) * progress
 
     expect(q.y).toBeCloseTo(fromOwnParent, 6)
-    // Not a distinction without a difference: the two are a visible distance
-    // apart, which is exactly the gap the owner was seeing.
+    // Not a distinction without a difference: a visible distance apart, which
+    // is the gap the owner was seeing.
     expect(Math.abs(fromOwnParent - fromToggledNode)).toBeGreaterThan(10)
   })
 
-  it("unfolds a revealed child from directly under the PARENT, in the child's own column", () => {
-    // The owner's ask, twice over: the reveal must not start "in the middle"
-    // of the parent, it must start "just underneath" it. So the growth-start
-    // box is flat against the parent's bottom edge — zero height, the fold
-    // line — but already at the child's OWN x and width, rather than a single
-    // point at the parent's centre that a whole row of children would then
-    // fan out from. See `growthBox` in engine.ts.
-    const SIMPLE: NodeData[] = [{ id: 'a' }, { id: 'q', parentId: 'a' }, { id: 'r', parentId: 'a' }]
+  it("grows a revealed child from the PARENT's exit edge (bottom-centre for tb), not its box origin/centre", () => {
+    // The owner's ask for task 2: children should visibly drop out of the
+    // bottom of the parent node, not balloon out of its middle. Single
+    // child, single parent, single root — nothing here recentres 'p' itself
+    // (unlike the LIVE-vs-STALE test above, which deliberately needs that),
+    // isolating just the growth-start POINT this test cares about.
+    const SIMPLE: NodeData[] = [{ id: 'a' }, { id: 'q', parentId: 'a' }]
     const renderer = fakeRenderer()
     const engine = createChartEngine(renderer)
     const tree = normalize(SIMPLE)
@@ -968,7 +1049,7 @@ describe('ChartEngine expand/collapse transition', () => {
     engine.setViewport(800, 600, 1)
     engine.setCamera({ x: 0, y: 0, k: 1 })
     const open = new Uint8Array(tree.count).fill(0) // 'a' starts collapsed
-    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'q', 'r'], open)
+    engine.setData(toWireTree(tree), sizesFor(tree.count), ['a', 'q'], open)
     engine.render(1000)
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
@@ -980,41 +1061,20 @@ describe('ChartEngine expand/collapse transition', () => {
     }
 
     engine.setOpen(tree.idToIndex.get('a')!, true)
-    engine.render(2000) // t=0 of the transition: both children sit exactly on their fold line
+    engine.render(2000) // t=0 of the transition: 'q' is at its growth-start point exactly
     const frame = renderer.frames.at(-1)!
-
-    for (const id of ['q', 'r']) {
-      const idx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get(id)!)
-      const start = {
-        x: frame.boxes[idx * 4]!,
-        y: frame.boxes[idx * 4 + 1]!,
-        w: frame.boxes[idx * 4 + 2]!,
-        h: frame.boxes[idx * 4 + 3]!,
-      }
-      const settledBox = {
-        x: engine.boxes[idx * 4]!,
-        w: engine.boxes[idx * 4 + 2]!,
-        h: engine.boxes[idx * 4 + 3]!,
-      }
-
-      // Tucked in behind the parent's bottom edge...
-      expect(start.y).toBeCloseTo(aBox.y + aBox.h, 6)
-      // ...at full size, so the card slides rather than unfolds — no
-      // squashed line, no ballooning.
-      expect(start.h).toBeCloseTo(settledBox.h, 6)
-      expect(start.w).toBeCloseTo(settledBox.w, 6)
-      // ...and already in its own column, NOT collapsed onto the parent's
-      // horizontal centre.
-      expect(start.x).toBeCloseTo(settledBox.x, 6)
-    }
-
-    // The two children start apart, which is the whole point: the old
-    // behaviour put both on the same point under the middle of 'a'.
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
-    const rIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('r')!)
-    expect(Math.abs(frame.boxes[qIdx * 4]! - frame.boxes[rIdx * 4]!)).toBeGreaterThan(50)
-    // ...and neither of them is the parent's centre.
-    expect(Math.abs(frame.boxes[qIdx * 4]! - (aBox.x + aBox.w / 2))).toBeGreaterThan(1)
+    const qStart = { x: frame.boxes[qIdx * 4]!, y: frame.boxes[qIdx * 4 + 1]! }
+
+    // Bottom edge, horizontal centre of 'a' — NOT 'a's top-left corner (the
+    // old, wrong growth-start point) and not 'a's own centre either.
+    expect(qStart.x).toBeCloseTo(aBox.x + aBox.w / 2, 6)
+    expect(qStart.y).toBeCloseTo(aBox.y + aBox.h, 6)
+    // A genuine POINT, not sized like the parent — confirms this grows from
+    // a single spot and expands outward, rather than starting already
+    // shaped like the whole parent box.
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
   })
 
   it("shrinks a collapsing ghost back into the PARENT's exit edge, not its box origin/centre", () => {
@@ -1030,8 +1090,6 @@ describe('ChartEngine expand/collapse transition', () => {
 
     engine.setOpen(tree.idToIndex.get('a')!, false) // collapse: 'q' becomes a ghost
     engine.render(1000)
-    const ghostStartX = renderer.frames.at(-1)!.ghostBoxes[0]!
-    const ghostHeight = renderer.frames.at(-1)!.ghostBoxes[3]!
 
     const aIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('a')!)
     const aBoxNow = {
@@ -1041,28 +1099,14 @@ describe('ChartEngine expand/collapse transition', () => {
       h: engine.boxes[aIdx * 4 + 3]!,
     }
 
-    // Where the ghost started, so the column assertion below has something
-    // to be true OF: it folds away in the place it occupied, not into a
-    // point under the middle of its parent.
-    const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
-    const qWasX = qIdx === -1 ? null : engine.boxes[qIdx * 4]!
-
     // Right at the end of the transition (but still just inside it): the
-    // ghost has nearly finished folding away, so its drawn box should sit
-    // almost exactly on its target.
+    // ghost has nearly finished shrinking toward its target, so its drawn
+    // box should sit almost exactly on 'a's exit point.
     engine.render(1000 + TRANSITION_MS - 1)
     const frame = renderer.frames.at(-1)!
     expect(frame.ghostCount).toBe(1)
-    // Tucked in behind 'a's bottom edge, still its own size — it slides
-    // away under the parent and fades, rather than shrinking to a line.
+    expect(frame.ghostBoxes[0]).toBeCloseTo(aBoxNow.x + aBoxNow.w / 2, 1)
     expect(frame.ghostBoxes[1]).toBeCloseTo(aBoxNow.y + aBoxNow.h, 1)
-    expect(frame.ghostBoxes[3]).toBeCloseTo(ghostHeight, 1)
-    // ...in its own column, keeping the width it had. `qWasX` is `null` only
-    // if 'q' had already left the pruned tree, which is the case here — it
-    // is a ghost — so the check is against the ghost's own starting x, which
-    // is where a collapse leaves it.
-    expect(frame.ghostBoxes[0]).toBeCloseTo(ghostStartX, 1)
-    expect(qWasX).toBeNull()
   })
 
   it("grows a revealed child from the parent's TRAILING edge under lr orientation, not its bottom edge", () => {
@@ -1096,15 +1140,10 @@ describe('ChartEngine expand/collapse transition', () => {
     const frame = renderer.frames.at(-1)!
     const qIdx = Array.from(engine.visibleToSource).indexOf(tree.idToIndex.get('q')!)
 
-    // Tucked in behind 'a's trailing (right) edge, at full size...
-    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6)
-    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(engine.boxes[qIdx * 4 + 2]!, 6)
-    // ...and already in its own ROW, at its own height: the growth axis is x
-    // here, so it is y that keeps what the child will settle with — the
-    // mirror of what the tb case asserts about x. Not 'a's vertical centre,
-    // which is where a single-point growth start would have put it.
-    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(engine.boxes[qIdx * 4 + 1]!, 6)
-    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(engine.boxes[qIdx * 4 + 3]!, 6)
+    expect(frame.boxes[qIdx * 4]).toBeCloseTo(aBox.x + aBox.w, 6) // right edge
+    expect(frame.boxes[qIdx * 4 + 1]).toBeCloseTo(aBox.y + aBox.h / 2, 6) // vertical centre
+    expect(frame.boxes[qIdx * 4 + 2]).toBeCloseTo(0, 6)
+    expect(frame.boxes[qIdx * 4 + 3]).toBeCloseTo(0, 6)
   })
 
   it('a second toggle mid-transition retargets from the current position instead of snapping', () => {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -534,29 +534,14 @@ function boxAt(boxes: Float64Array, i: number): Box {
  * camera is. Styles with no mark (`folder`) start at the plain exit point —
  * there is no tip to start from.
  */
-function revealOrigin(
-  settled: Box,
-  box: Box,
-  horizontal: boolean,
-  style: EdgeStyle,
-  rtl: boolean,
-  k: number,
-): Box {
+function revealOrigin(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean, k: number): Box {
   const exit = exitBox(box, horizontal, style, rtl)
   const stub = hiddenStub(style, horizontal, rtl, box.x, box.y, box.w, box.h)
+  if (stub === null || k <= 0) return exit
   // Past the dot, not merely to it: the dot has a radius, and starting inside
   // it reads as the card emerging from behind the mark.
-  const reach = stub === null || k <= 0 ? 0 : (HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2) / k
-  const dx = stub?.dx ?? 0
-  const dy = stub?.dy ?? 0
-  // The child's own size, kept. We know what it is going to be, so there is
-  // nothing to discover by growing it out of nothing — and growing it out of
-  // nothing is what put its top-left corner at the start point and left the
-  // card looking like it came out of that corner. It starts whole, one mark's
-  // length below (or beyond) the parent, and travels to its row.
-  return horizontal
-    ? { x: exit.x + dx * reach, y: settled.y, w: settled.w, h: settled.h }
-    : { x: settled.x, y: exit.y + dy * reach, w: settled.w, h: settled.h }
+  const reach = (HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2) / k
+  return { x: exit.x + stub.dx * reach, y: exit.y + stub.dy * reach, w: 0, h: 0 }
 }
 
 function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean): Box {
@@ -2185,6 +2170,29 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
       // recursive call always takes the non-revealed branch below and
       // returns without recursing further, one level deep regardless of
       // how far up the tree the anchor sits.
+      /**
+       * The box a reveal grows out of, given its anchor.
+       *
+       * LIVE (`renderBoxes`) for an anchor that is merely moving: it is
+       * sliding to make room or recentring over a changed child set, and a
+       * child growing out of where it used to be visibly hangs off it.
+       *
+       * SETTLED (`boxes`) for an anchor that is ITSELF being revealed — a
+       * deep expand, where a whole chain appears at once because the open
+       * state below was remembered. Live, that anchor is a point near ITS
+       * own parent for the first part of the reveal, so every level below
+       * the first grew out of a spot a row or more too high and the whole
+       * branch bunched up at the top before spreading out. The owner, on a
+       * fast expand: "it still comes from the very top." A node that is
+       * arriving has no meaningful current position to offer a child; where
+       * it is going is the honest answer, and it is where the mark the child
+       * grows out of will be.
+       */
+      const anchorBoxFor = (anchor: number): Box => {
+        const entry = transition!.fromBySource.get(visibleToSource[anchor]!)
+        return entry !== undefined && entry.revealed ? boxAt(boxes, anchor) : boxAt(renderBoxes, anchor)
+      }
+
       const applyTween = (idx: number): void => {
         const entry = transition!.fromBySource.get(visibleToSource[idx]!)
         if (entry === undefined) return
@@ -2203,14 +2211,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           // anchor's LIVE position: the parent is often mid-move itself while
           // this runs, and a child starting from where the parent used to be
           // visibly hangs off it.
-          from = revealOrigin(
-            settled,
-            boxAt(renderBoxes, entry.anchor),
-            horizontal,
-            edgeStyle,
-            options.rtl,
-            camera.k,
-          )
+          from = revealOrigin(anchorBoxFor(entry.anchor), horizontal, edgeStyle, options.rtl, camera.k)
         }
         writeBox(renderBoxes, idx, lerpBox(from, settled, easing.emphasisPos))
       }
@@ -2279,14 +2280,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
             // collapsing ghost leaves the way it arrived, sliding back behind
             // the mark on its surviving ancestor rather than shrinking into a
             // point somewhere under the middle of it.
-            to = revealOrigin(
-              ghost.from,
-              boxAt(renderBoxes, ghost.anchor),
-              horizontal,
-              edgeStyle,
-              options.rtl,
-              camera.k,
-            )
+            to = revealOrigin(anchorBoxFor(ghost.anchor), horizontal, edgeStyle, options.rtl, camera.k)
           }
           writeBox(ghostDrawBoxes, g, lerpBox(ghost.from, to, easing.emphasisPos))
           ghostDrawAlpha[g] = easing.ghostAlpha

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -968,6 +968,17 @@ function buildTransition(
   prevVisibleToSource: Int32Array,
   prevParent: Int32Array,
   prevTransition: Transition | null,
+  /**
+   * The interpolated boxes the LAST FRAME was drawn with, in the previous
+   * relayout's pruned index space — the engine's own `renderBoxes`, which it
+   * has not replaced yet at the point it calls this.
+   *
+   * Only a node caught mid-reveal needs it; see the `entry.revealed` branch
+   * below for why that one cannot be recomputed from `prevTransition` alone.
+   * Identical to `prevBoxes` for anything the last frame did not draw, which
+   * is the right answer for a node off screen anyway.
+   */
+  prevRenderBoxes: Float64Array,
   boxes: Float64Array,
   visibleToSource: Int32Array,
   prunedParent: Int32Array,
@@ -1008,8 +1019,27 @@ function buildTransition(
     if (prevTransition !== null) {
       const entry = prevTransition.fromBySource.get(src)
       if (entry !== undefined) {
-        const t = entry.revealed ? prevEasing!.emphasisPos : prevEasing!.repositionPos
-        box = lerpBox(entry.box, box, t)
+        if (entry.revealed) {
+          // A node caught mid-REVEAL is read straight out of the frame that
+          // drew it (`prevRenderBoxes`), not recomputed here.
+          //
+          // It cannot be recomputed here, and pretending otherwise was a bug
+          // with a very particular look. A revealed entry's `box` field is
+          // its FINAL box — the growth START is not stored at all, it is
+          // resolved live from the anchor every frame (see `TweenEntry.box`
+          // and `render()`'s `applyTween`) — so `lerpBox(entry.box, box, t)`
+          // was lerping the final box towards itself and handing back the
+          // final box whatever `t` said. Interrupt an expand and every card
+          // still growing was recorded at full size in its finished
+          // position, then tweened on from there by the new transition: they
+          // jumped out of the parent to their full size and then set off
+          // again, which is what a fast second click looked like. The frame
+          // buffer has the honest answer already — it is exactly what the
+          // viewer was looking at when the click landed.
+          box = boxAt(prevRenderBoxes, i)
+        } else {
+          box = lerpBox(entry.box, box, prevEasing!.repositionPos)
+        }
       }
     }
     // Keyed in the NEW index space, so every lookup downstream — reveals,
@@ -1648,6 +1678,10 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
 
   const relayout = (now: number): void => {
     const prevBoxes = boxes
+    // The frame buffer as the last frame left it, before `renderBoxes` is
+    // pointed at the new layout below — see `buildTransition`'s
+    // `prevRenderBoxes` for the one thing that needs it.
+    const prevRenderBoxes = renderBoxes
     const prevVisibleToSource = visibleToSource
     const prevParent = prunedParent
     const prevTransition = transition
@@ -1857,6 +1891,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
         prevVisibleToSource,
         prevParent,
         prevTransition,
+        prevRenderBoxes,
         boxes,
         visibleToSource,
         prunedParent,

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -491,12 +491,10 @@ function boxAt(boxes: Float64Array, i: number): Box {
 }
 
 /** `Box`-typed convenience wrapper over `exitPointXY` (see its docblock) —
- * as a zero-size `Box` (`w`/`h` both 0), ready to hand straight to `lerpBox`
- * as a reveal's growth-start point or a ghost's shrink-target point: a
- * revealed child then visibly emerges from a single POINT at its parent's
- * exit edge and grows to its own size while moving to its final box, rather
- * than starting already sized like the whole parent box — see `render()`'s
- * `applyTween` and the ghost-drawing loop, both in `createChartEngine`. */
+ * as a zero-size `Box` (`w`/`h` both 0). Read for its EXIT COORDINATE by
+ * `growthBox` below, which is what actually starts a reveal and ends a
+ * collapse; see `render()`'s `applyTween` and the ghost-drawing loop, both in
+ * `createChartEngine`. */
 function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean): Box {
   // Where a revealed child grows FROM has to be where its connector attaches,
   // or the two disagree in the one moment a viewer is watching them: the card
@@ -506,6 +504,33 @@ function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean):
   // a zero-size box at the parent is enough to ask with.
   const a = edgeAnchors(style, horizontal, rtl, box.x, box.y, box.w, box.h, box.x, box.y, 0, 0)
   return { x: a.px, y: a.py, w: 0, h: 0 }
+}
+
+/**
+ * Where a revealed child starts, and where a collapsing one ends: flat
+ * against its parent's exit edge, in its OWN column.
+ *
+ * `settled` is the child's own final box (its `from` box, for a ghost). Only
+ * the growth axis is taken from the parent — y for tb/bt, x for lr/rl — and
+ * only as a line: zero height under the parent's bottom edge, zero width past
+ * its trailing edge. Across the axis the child keeps everything it will end
+ * up with, its position and its size both.
+ *
+ * The previous version started every child at a single POINT on the parent —
+ * the exact spot its connector attaches — so a wide row of children all
+ * erupted from the middle of the parent's bottom edge and fanned outwards to
+ * their places. The owner's words: it should not start "in the middle", it
+ * should start "just underneath". So each child now unfolds straight down out
+ * of the parent's underside, at the column it is going to occupy, and its
+ * connector grows with it instead of sweeping sideways across the ones next
+ * to it. That also makes the reveal read as one row opening rather than as N
+ * cards flying apart, which is what a viewer opening a branch is actually
+ * looking for.
+ */
+function growthBox(settled: Box, exit: Box, horizontal: boolean): Box {
+  return horizontal
+    ? { x: exit.x, y: settled.y, w: 0, h: settled.h }
+    : { x: settled.x, y: exit.y, w: settled.w, h: 0 }
 }
 
 function writeBox(target: Float64Array, i: number, box: Box): void {
@@ -1030,44 +1055,35 @@ function buildTransition(
     }
   }
 
-  // 2. Surviving (tweened) and newly-revealed nodes. `resolveRevealAnchor`
-  // walks the NEW tree's parent chain looking for the nearest ancestor with a
-  // prior position, memoizing every pruned index it passes through so a
-  // multi-level reveal (expanding a grandparent) costs O(1) amortized per
-  // node instead of O(depth) per node. It returns that ancestor's PRUNED
-  // INDEX, not a baked box — see `TweenEntry.anchor`'s docblock for why.
+  // 2. Surviving (tweened) and newly-revealed nodes. A revealed node grows
+  // out of its OWN PARENT, whenever it has one in this tree — even a parent
+  // that is itself being revealed this transition. It returns a PRUNED INDEX,
+  // not a baked box — see `TweenEntry.anchor`'s docblock for why.
+  //
+  // It used to walk UP past any such parent, to the nearest ancestor that had
+  // a prior position, on the reasoning that a node with no position of its
+  // own has nothing to grow from. But it does: by the time `render()` asks,
+  // that parent has been tweened too (`applyTween` resolves its anchor first,
+  // recursively), so it has a live box at every instant, and it is the right
+  // one. The walk's version showed itself the moment a branch whose
+  // GRANDCHILDREN were also open got expanded — the common case, since open
+  // state is remembered: every level below the first erupted from the toggled
+  // node's bottom edge, above the row it belonged to, instead of unfolding
+  // out of its own parent a level at a time. The owner's "they can even come
+  // out from higher up".
+  //
+  // The chain terminates: `prunedParent` is a tree, so following it strictly
+  // decreases depth, and preorder guarantees a parent's pruned index is lower
+  // than its children's — which is also what lets the `nodeQuad` pass below
+  // read an anchor's union box that a revealed anchor only writes in the same
+  // loop.
   const fromBySource = new Map<number, TweenEntry>()
-  const revealCache = new Map<number, number>()
-  const resolveRevealAnchor = (i: number): number => {
-    const cached = revealCache.get(i)
-    if (cached !== undefined) return cached
-    const path: number[] = []
-    let p = prunedParent[i]!
-    let result = -1
-    while (p !== -1) {
-      const viaCache = revealCache.get(p)
-      if (viaCache !== undefined) {
-        result = viaCache
-        break
-      }
-      const psrc = visibleToSource[p]!
-      if (prevPositionBySource.has(psrc)) {
-        result = p
-        break
-      }
-      path.push(p)
-      p = prunedParent[p]!
-    }
-    for (const idx of path) revealCache.set(idx, result)
-    revealCache.set(i, result)
-    return result
-  }
 
   for (let i = 0; i < visibleToSource.length; i++) {
     const src = visibleToSource[i]!
     const prev = prevPositionBySource.get(src)
     if (prev !== undefined) fromBySource.set(src, { box: prev, revealed: false, anchor: -1 })
-    else fromBySource.set(src, { box: boxAt(boxes, i), revealed: true, anchor: resolveRevealAnchor(i) })
+    else fromBySource.set(src, { box: boxAt(boxes, i), revealed: true, anchor: prunedParent[i]! })
   }
 
   // 3. Removed nodes become ghosts, collapsing toward the nearest ancestor
@@ -2104,20 +2120,21 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           writeBox(renderBoxes, idx, lerpBox(entry.box, boxAt(boxes, idx), easing.repositionPos))
           return
         }
+        const settled = boxAt(boxes, idx)
         let from = entry.box
         if (entry.anchor !== -1) {
           applyTween(entry.anchor)
-          // The anchor's EXIT point (bottom edge for tb/bt, trailing edge for
-          // lr/rl — wherever its connector actually leaves it), not its whole
-          // box: a revealed child emerges from that single point on its
-          // parent and grows to its own size while moving to its final box,
-          // rather than starting already sized and positioned like the
-          // entire parent — the owner's ask (previously it grew out of the
-          // anchor's box origin/centre, which read as ballooning out of the
-          // middle rather than dropping out of the bottom).
-          from = exitBox(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl)
+          // Flat against the anchor's EXIT edge (its bottom for tb/bt, its
+          // trailing side for lr/rl — wherever its connector actually leaves
+          // it), in this child's own column: see `growthBox`. Read from
+          // `renderBoxes`, so it tracks the anchor's LIVE position — the
+          // parent is usually mid-reposition itself while this runs, and a
+          // child unfolding from where the parent used to be would visibly
+          // hang off it.
+          const exit = exitBox(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl)
+          from = growthBox(settled, exit, horizontal)
         }
-        writeBox(renderBoxes, idx, lerpBox(from, boxAt(boxes, idx), easing.emphasisPos))
+        writeBox(renderBoxes, idx, lerpBox(from, settled, easing.emphasisPos))
       }
       // Every drawn NODE needs its own box tweened, plus its parent's (so
       // a connector reaching up to that parent, drawn from the same
@@ -2180,12 +2197,16 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           let to = ghost.from
           if (ghost.anchor !== -1) {
             applyTween(ghost.anchor)
-            // Symmetric with the reveal case above: a collapsing ghost
-            // shrinks toward the single EXIT point on its surviving
-            // ancestor, not the ancestor's whole box, so it visibly
-            // disappears back into the bottom/trailing edge it originally
-            // emerged from rather than shrinking into the ancestor's centre.
-            to = exitBox(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl)
+            // Symmetric with the reveal case above, and for the same reason:
+            // a collapsing ghost folds flat against its surviving ancestor's
+            // exit edge in the column it already occupies, so it leaves the
+            // way it arrived instead of sliding sideways into a point under
+            // the middle of the parent.
+            to = growthBox(
+              ghost.from,
+              exitBox(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl),
+              horizontal,
+            )
           }
           writeBox(ghostDrawBoxes, g, lerpBox(ghost.from, to, easing.emphasisPos))
           ghostDrawAlpha[g] = easing.ghostAlpha

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -534,14 +534,29 @@ function boxAt(boxes: Float64Array, i: number): Box {
  * camera is. Styles with no mark (`folder`) start at the plain exit point —
  * there is no tip to start from.
  */
-function revealOrigin(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean, k: number): Box {
+function revealOrigin(
+  settled: Box,
+  box: Box,
+  horizontal: boolean,
+  style: EdgeStyle,
+  rtl: boolean,
+  k: number,
+): Box {
   const exit = exitBox(box, horizontal, style, rtl)
   const stub = hiddenStub(style, horizontal, rtl, box.x, box.y, box.w, box.h)
-  if (stub === null || k <= 0) return exit
   // Past the dot, not merely to it: the dot has a radius, and starting inside
   // it reads as the card emerging from behind the mark.
-  const reach = (HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2) / k
-  return { x: exit.x + stub.dx * reach, y: exit.y + stub.dy * reach, w: 0, h: 0 }
+  const reach = stub === null || k <= 0 ? 0 : (HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2) / k
+  const dx = stub?.dx ?? 0
+  const dy = stub?.dy ?? 0
+  // The child's own size, kept. We know what it is going to be, so there is
+  // nothing to discover by growing it out of nothing — and growing it out of
+  // nothing is what put its top-left corner at the start point and left the
+  // card looking like it came out of that corner. It starts whole, one mark's
+  // length below (or beyond) the parent, and travels to its row.
+  return horizontal
+    ? { x: exit.x + dx * reach, y: settled.y, w: settled.w, h: settled.h }
+    : { x: settled.x, y: exit.y + dy * reach, w: settled.w, h: settled.h }
 }
 
 function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean): Box {
@@ -2183,12 +2198,19 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           applyTween(entry.anchor)
           // The anchor's EXIT point (bottom-centre for tb/bt, trailing edge
           // for lr/rl — wherever its connector leaves it, which is exactly
-          // where the collapsed-state indicator hangs from), and the child
-          // scales up out of it in both directions and downwards. Read from
-          // `renderBoxes`, so it tracks the anchor's LIVE position: the
-          // parent is often mid-move itself while this runs, and a child
-          // growing out of where the parent used to be visibly hangs off it.
-          from = revealOrigin(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl, camera.k)
+          // where the collapsed-state indicator hangs from), one mark's
+          // length past its tip. Read from `renderBoxes`, so it tracks the
+          // anchor's LIVE position: the parent is often mid-move itself while
+          // this runs, and a child starting from where the parent used to be
+          // visibly hangs off it.
+          from = revealOrigin(
+            settled,
+            boxAt(renderBoxes, entry.anchor),
+            horizontal,
+            edgeStyle,
+            options.rtl,
+            camera.k,
+          )
         }
         writeBox(renderBoxes, idx, lerpBox(from, settled, easing.emphasisPos))
       }
@@ -2253,12 +2275,18 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           let to = ghost.from
           if (ghost.anchor !== -1) {
             applyTween(ghost.anchor)
-            // Symmetric with the reveal case above, and for the same reason:
-            // a collapsing ghost folds flat against its surviving ancestor's
-            // exit edge in the column it already occupies, so it leaves the
-            // way it arrived instead of sliding sideways into a point under
-            // the middle of the parent.
-            to = revealOrigin(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl, camera.k)
+            // Symmetric with the reveal above, and for the same reason: a
+            // collapsing ghost leaves the way it arrived, sliding back behind
+            // the mark on its surviving ancestor rather than shrinking into a
+            // point somewhere under the middle of it.
+            to = revealOrigin(
+              ghost.from,
+              boxAt(renderBoxes, ghost.anchor),
+              horizontal,
+              edgeStyle,
+              options.rtl,
+              camera.k,
+            )
           }
           writeBox(ghostDrawBoxes, g, lerpBox(ghost.from, to, easing.emphasisPos))
           ghostDrawAlpha[g] = easing.ghostAlpha

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -563,22 +563,40 @@ function unionBox(a: Box, b: Box): Box {
  * one does (reposition vs. reveal/shrink) flips with the toggle's direction
  * — see `Transition.opening` and `repositionRaw`/`emphasisRaw` below.
  *
- * `PHASE_OVERLAP_MS` lets phase 2 start a little before phase 1 fully
- * finishes, so the hand-off between them reads as one continuous motion
- * rather than two animations with a dead beat in between — small relative to
- * either phase, tuned by eye alongside the phase lengths themselves.
+ * `PHASE_OVERLAP_MS` lets phase 2 start before phase 1 finishes, so the
+ * hand-off between them reads as one continuous motion rather than two
+ * animations with a dead beat in between.
+ *
+ * It is a THIRD of a phase, not the token 70ms it started as, because both
+ * phases are eased with `easeInOutCubic` — each ENDS at zero velocity and
+ * each STARTS at zero velocity. Overlap them by less than their own
+ * slow-in/slow-out tails and the two near-stationary ends line up: the
+ * children finish shrinking away, the chart visibly waits, and only then do
+ * the siblings close the gap. That pause was the owner's "it shrinks, it
+ * closes, then it shrinks again". At a third of a phase, phase 2's
+ * acceleration lands inside phase 1's fast middle instead, and the pair reads
+ * as one move.
+ *
+ * It does NOT go further than that, which would be the same as not staging
+ * the transition at all: on an expand the children would arrive into space
+ * that has not been made yet and sit over their neighbours on the way in,
+ * which is the thing the staging exists to prevent. The floor for a collapse
+ * is `GHOST_FADE_FRACTION` — the gap must not start closing over children
+ * that are still visible — and phase 2 opening at ~33% against a fade that
+ * completes by 35% (and only reaching real speed after that, being eased)
+ * keeps it on the right side of that line.
  *
  * Total duration (`TRANSITION_DURATION_MS`, derived below) intentionally
  * stays quick: the owner was explicit that the whole thing must not feel
  * slow, even now that it is two stages rather than one. The former
  * single-phase duration was 420ms; splitting it in two without shortening
  * anything would have doubled the perceived length, so each phase is
- * shorter than that on its own — the two phases together, minus the
- * overlap, land at roughly the same ballpark as before.
+ * shorter than that on its own — and the wider overlap now brings the two
+ * together back under it.
  */
 const PHASE_ONE_MS = 260
 const PHASE_TWO_MS = 260
-const PHASE_OVERLAP_MS = 70
+const PHASE_OVERLAP_MS = 130
 const TRANSITION_DURATION_MS = PHASE_ONE_MS + PHASE_TWO_MS - PHASE_OVERLAP_MS
 
 /** Fraction of the total duration phase 1 alone occupies. */

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -2,7 +2,14 @@ import type { Bounds } from './types.js'
 import type { Camera } from './viewport.js'
 import type { EdgeStyle, Renderer } from './render/renderer.js'
 import type { DropMode } from './drag/drop-target.js'
-import { edgeAnchors, edgeBBox, edgeStyleDrawsConnectors } from './render/edge-geometry.js'
+import {
+  edgeAnchors,
+  edgeBBox,
+  edgeStyleDrawsConnectors,
+  hiddenStub,
+  HIDDEN_DOT_PX,
+  HIDDEN_STUB_PX,
+} from './render/edge-geometry.js'
 import { isSectorVisible } from './render/sector.js'
 import type { ExportData } from './render/svg.js'
 import type { EngineOptions, WireTree } from './worker/protocol.js'
@@ -509,6 +516,34 @@ function boxAt(boxes: Float64Array, i: number): Box {
  * See `render()`'s `applyTween` and the ghost-drawing loop, both in
  * `createChartEngine`.
  */
+/**
+ * Where a reveal actually starts, and where a collapse ends: just past the
+ * tip of the "more inside" mark that hangs off the node while it is shut.
+ *
+ * The mark IS the promise — a short stub off the node's exit edge ending in a
+ * dot, the one thing on a closed branch that says something is in there. So a
+ * branch opening out of the end of it is the promise being kept, in the place
+ * it was made. Starting flush against the node's own edge instead, which is
+ * what this did, put the first frame of the reveal underneath the card and
+ * behind the mark: the owner saw the children arrive "from the very top",
+ * touching the parent, rather than out of the tip a few pixels below it.
+ *
+ * `k` converts the mark's SCREEN length into world units, because that is how
+ * the mark itself is drawn (see `HIDDEN_STUB_PX`): the same handful of pixels
+ * at every zoom, so the reveal starts the same distance out however far the
+ * camera is. Styles with no mark (`folder`) start at the plain exit point —
+ * there is no tip to start from.
+ */
+function revealOrigin(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean, k: number): Box {
+  const exit = exitBox(box, horizontal, style, rtl)
+  const stub = hiddenStub(style, horizontal, rtl, box.x, box.y, box.w, box.h)
+  if (stub === null || k <= 0) return exit
+  // Past the dot, not merely to it: the dot has a radius, and starting inside
+  // it reads as the card emerging from behind the mark.
+  const reach = (HIDDEN_STUB_PX + HIDDEN_DOT_PX * 2) / k
+  return { x: exit.x + stub.dx * reach, y: exit.y + stub.dy * reach, w: 0, h: 0 }
+}
+
 function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean): Box {
   // Where a revealed child grows FROM has to be where its connector attaches,
   // or the two disagree in the one moment a viewer is watching them: the card
@@ -2153,7 +2188,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
           // `renderBoxes`, so it tracks the anchor's LIVE position: the
           // parent is often mid-move itself while this runs, and a child
           // growing out of where the parent used to be visibly hangs off it.
-          from = exitBox(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl)
+          from = revealOrigin(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl, camera.k)
         }
         writeBox(renderBoxes, idx, lerpBox(from, settled, easing.emphasisPos))
       }
@@ -2223,7 +2258,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
             // exit edge in the column it already occupies, so it leaves the
             // way it arrived instead of sliding sideways into a point under
             // the middle of the parent.
-            to = exitBox(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl)
+            to = revealOrigin(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl, camera.k)
           }
           writeBox(ghostDrawBoxes, g, lerpBox(ghost.from, to, easing.emphasisPos))
           ghostDrawAlpha[g] = easing.ghostAlpha

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -490,11 +490,25 @@ function boxAt(boxes: Float64Array, i: number): Box {
   return { x: boxes[o]!, y: boxes[o + 1]!, w: boxes[o + 2]!, h: boxes[o + 3]! }
 }
 
-/** `Box`-typed convenience wrapper over `exitPointXY` (see its docblock) —
- * as a zero-size `Box` (`w`/`h` both 0). Read for its EXIT COORDINATE by
- * `growthBox` below, which is what actually starts a reveal and ends a
- * collapse; see `render()`'s `applyTween` and the ghost-drawing loop, both in
- * `createChartEngine`. */
+/**
+ * `Box`-typed convenience wrapper over `exitPointXY` (see its docblock) — as a
+ * zero-size `Box` (`w`/`h` both 0), ready to hand straight to `lerpBox` as a
+ * reveal's growth-start point or a ghost's shrink-target point.
+ *
+ * A single POINT, on purpose, and the owner has now confirmed it twice over:
+ * the child grows out of the spot the collapsed node's own indicator hangs
+ * from — bottom edge, horizontal centre — opening outwards in both directions
+ * and downwards from there. Two alternatives were tried against that and both
+ * were rejected on sight: keeping the child's own column and unfolding it out
+ * of a zero-height line (every card stretching open, far too much
+ * distortion), and keeping its whole box and sliding it down (no distortion,
+ * but the reveal stops reading as coming OUT of the parent at all). What was
+ * actually wrong was never this point — it was which node's point a deeper
+ * descendant used; see the anchor in `buildTransition`.
+ *
+ * See `render()`'s `applyTween` and the ghost-drawing loop, both in
+ * `createChartEngine`.
+ */
 function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean): Box {
   // Where a revealed child grows FROM has to be where its connector attaches,
   // or the two disagree in the one moment a viewer is watching them: the card
@@ -504,32 +518,6 @@ function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean):
   // a zero-size box at the parent is enough to ask with.
   const a = edgeAnchors(style, horizontal, rtl, box.x, box.y, box.w, box.h, box.x, box.y, 0, 0)
   return { x: a.px, y: a.py, w: 0, h: 0 }
-}
-
-/**
- * Where a revealed child starts, and where a collapsing one ends: its own box,
- * whole, tucked in behind its parent's exit edge.
- *
- * `settled` is the child's own final box (its `from` box, for a ghost). Only
- * the growth-axis coordinate comes from the parent — the child's top for
- * tb/bt, its leading side for lr/rl, placed exactly on the edge the connector
- * leaves from. Everything else is the child's own: its column, and crucially
- * its SIZE. So the reveal is a slide out from under the parent (plus the
- * fade), and nothing about the card is distorted on the way.
- *
- * Two earlier versions of this, both rejected by the owner on sight. Starting
- * at a single POINT on the parent's bottom edge made a row of children erupt
- * from the middle of it and fan outwards — "the start point should not be the
- * middle, it should be just underneath". Starting flat — the child's own
- * column but zero height — fixed the fanning and replaced it with something
- * worse: every card unfolding out of a squashed line, which at card sizes is
- * a lot of distortion for one gesture to carry. Keeping the box intact and
- * moving it is the version with no distortion in it at all.
- */
-function growthBox(settled: Box, exit: Box, horizontal: boolean): Box {
-  return horizontal
-    ? { x: exit.x, y: settled.y, w: settled.w, h: settled.h }
-    : { x: settled.x, y: exit.y, w: settled.w, h: settled.h }
 }
 
 function writeBox(target: Float64Array, i: number, box: Box): void {
@@ -2123,15 +2111,14 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
         let from = entry.box
         if (entry.anchor !== -1) {
           applyTween(entry.anchor)
-          // Flat against the anchor's EXIT edge (its bottom for tb/bt, its
-          // trailing side for lr/rl — wherever its connector actually leaves
-          // it), in this child's own column: see `growthBox`. Read from
-          // `renderBoxes`, so it tracks the anchor's LIVE position — the
-          // parent is usually mid-reposition itself while this runs, and a
-          // child unfolding from where the parent used to be would visibly
-          // hang off it.
-          const exit = exitBox(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl)
-          from = growthBox(settled, exit, horizontal)
+          // The anchor's EXIT point (bottom-centre for tb/bt, trailing edge
+          // for lr/rl — wherever its connector leaves it, which is exactly
+          // where the collapsed-state indicator hangs from), and the child
+          // scales up out of it in both directions and downwards. Read from
+          // `renderBoxes`, so it tracks the anchor's LIVE position: the
+          // parent is often mid-move itself while this runs, and a child
+          // growing out of where the parent used to be visibly hangs off it.
+          from = exitBox(boxAt(renderBoxes, entry.anchor), horizontal, edgeStyle, options.rtl)
         }
         writeBox(renderBoxes, idx, lerpBox(from, settled, easing.emphasisPos))
       }
@@ -2201,11 +2188,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
             // exit edge in the column it already occupies, so it leaves the
             // way it arrived instead of sliding sideways into a point under
             // the middle of the parent.
-            to = growthBox(
-              ghost.from,
-              exitBox(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl),
-              horizontal,
-            )
+            to = exitBox(boxAt(renderBoxes, ghost.anchor), horizontal, edgeStyle, options.rtl)
           }
           writeBox(ghostDrawBoxes, g, lerpBox(ghost.from, to, easing.emphasisPos))
           ghostDrawAlpha[g] = easing.ghostAlpha

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -507,30 +507,29 @@ function exitBox(box: Box, horizontal: boolean, style: EdgeStyle, rtl: boolean):
 }
 
 /**
- * Where a revealed child starts, and where a collapsing one ends: flat
- * against its parent's exit edge, in its OWN column.
+ * Where a revealed child starts, and where a collapsing one ends: its own box,
+ * whole, tucked in behind its parent's exit edge.
  *
  * `settled` is the child's own final box (its `from` box, for a ghost). Only
- * the growth axis is taken from the parent — y for tb/bt, x for lr/rl — and
- * only as a line: zero height under the parent's bottom edge, zero width past
- * its trailing edge. Across the axis the child keeps everything it will end
- * up with, its position and its size both.
+ * the growth-axis coordinate comes from the parent — the child's top for
+ * tb/bt, its leading side for lr/rl, placed exactly on the edge the connector
+ * leaves from. Everything else is the child's own: its column, and crucially
+ * its SIZE. So the reveal is a slide out from under the parent (plus the
+ * fade), and nothing about the card is distorted on the way.
  *
- * The previous version started every child at a single POINT on the parent —
- * the exact spot its connector attaches — so a wide row of children all
- * erupted from the middle of the parent's bottom edge and fanned outwards to
- * their places. The owner's words: it should not start "in the middle", it
- * should start "just underneath". So each child now unfolds straight down out
- * of the parent's underside, at the column it is going to occupy, and its
- * connector grows with it instead of sweeping sideways across the ones next
- * to it. That also makes the reveal read as one row opening rather than as N
- * cards flying apart, which is what a viewer opening a branch is actually
- * looking for.
+ * Two earlier versions of this, both rejected by the owner on sight. Starting
+ * at a single POINT on the parent's bottom edge made a row of children erupt
+ * from the middle of it and fan outwards — "the start point should not be the
+ * middle, it should be just underneath". Starting flat — the child's own
+ * column but zero height — fixed the fanning and replaced it with something
+ * worse: every card unfolding out of a squashed line, which at card sizes is
+ * a lot of distortion for one gesture to carry. Keeping the box intact and
+ * moving it is the version with no distortion in it at all.
  */
 function growthBox(settled: Box, exit: Box, horizontal: boolean): Box {
   return horizontal
-    ? { x: exit.x, y: settled.y, w: 0, h: settled.h }
-    : { x: settled.x, y: exit.y, w: settled.w, h: 0 }
+    ? { x: exit.x, y: settled.y, w: settled.w, h: settled.h }
+    : { x: settled.x, y: exit.y, w: settled.w, h: settled.h }
 }
 
 function writeBox(target: Float64Array, i: number, box: Box): void {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1014,6 +1014,23 @@ function buildTransition(
    * is the right answer for a node off screen anyway.
    */
   prevRenderBoxes: Float64Array,
+  /**
+   * The same thing for the nodes that were on their way OUT when this
+   * relayout landed: SOURCE -> the box the last frame actually drew that
+   * ghost at, empty when none were drawn.
+   *
+   * A ghost is not in `prevRenderBoxes` — it has left the pruned tree, which
+   * is what makes it a ghost — so it needs its own answer, and for the same
+   * reason: where it visually IS cannot be recomputed from the transition
+   * that was drawing it. See the carry-over loop below.
+   *
+   * Built by the caller from the engine's OWN scratch buffers rather than
+   * from `lastGhostSource`/`lastGhostBoxes`: those are handed to the host and,
+   * in worker mode, TRANSFERRED — detached the moment they are posted, so
+   * reading them back here finds a zero-length array and silently falls
+   * through to the recomputation this parameter exists to replace.
+   */
+  prevGhostDrawn: ReadonlyMap<number, Box>,
   boxes: Float64Array,
   visibleToSource: Int32Array,
   prunedParent: Int32Array,
@@ -1096,13 +1113,32 @@ function buildTransition(
         // a still-fading ghost tracking its anchor's OWN live reposition
         // tween — same "live anchor, not a stale snapshot" fix as
         // `render()`'s ghost-drawing loop.
+        const key = sourceRemap === null ? ghost.source : (sourceRemap[ghost.source] ?? -1)
+        if (key === -1) continue
+        // The frame buffer first, exactly as a mid-reveal node is read out of
+        // `prevRenderBoxes` above, and for the same reason: recomputing it
+        // here does not agree with what was drawn. `render()` shrinks a ghost
+        // toward a POINT on its anchor — the tip of the "more inside" mark,
+        // see `revealOrigin` — while this used the anchor's whole BOX as the
+        // target. At the end of a collapse that put the ghost at the parent's
+        // full-size box, and an expand landing there started every child from
+        // the parent's own top-left corner at full size and flew it down to
+        // its place. Measured on a real page: three cards, all at exactly the
+        // parent's box, on every expand that interrupted a collapse — the
+        // owner's "when I click fast it starts from above the mouse, almost
+        // at the top border". The recomputation stays as the fallback for a
+        // ghost the last frame did not draw (off screen, or none drawn yet).
+        const drawnAt = prevGhostDrawn.get(ghost.source)
+        if (drawnAt !== undefined) {
+          prevPositionBySource.set(key, drawnAt)
+          continue
+        }
         const anchorKey = sourceRemap === null ? ghost.anchorSource : (sourceRemap[ghost.anchorSource] ?? -1)
         const to =
           ghost.anchor === -1 || anchorKey === -1
             ? ghost.from
             : (prevPositionBySource.get(anchorKey) ?? ghost.from)
-        const key = sourceRemap === null ? ghost.source : (sourceRemap[ghost.source] ?? -1)
-        if (key !== -1) prevPositionBySource.set(key, lerpBox(ghost.from, to, prevEasing!.emphasisPos))
+        prevPositionBySource.set(key, lerpBox(ghost.from, to, prevEasing!.emphasisPos))
       }
     }
   }
@@ -1606,6 +1642,13 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
   let renderBoxes: Float64Array = new Float64Array(0)
   let ghostCullBuffer = new Uint32Array(0)
   let ghostDrawBoxes = new Float64Array(0)
+  /**
+   * How many entries of `ghostDrawBoxes` the last frame actually wrote —
+   * `render()`'s own ghost count, kept here so `relayout` can read the frame
+   * back afterwards (see `buildTransition`'s `prevGhostDrawn`). The buffer
+   * itself is grown and reused, so its length says nothing about this.
+   */
+  let ghostDrawCount = 0
   let ghostDrawAlpha = new Float32Array(0)
   let revealAlphaBuffer = new Float32Array(0)
   // Interpolated boxes for exactly the SOURCE indices `render()` most
@@ -1717,6 +1760,18 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
     // pointed at the new layout below — see `buildTransition`'s
     // `prevRenderBoxes` for the one thing that needs it.
     const prevRenderBoxes = renderBoxes
+    // ...and the ghost half of the same frame, for the nodes that had already
+    // left the tree when this relayout landed. Read out of the engine's own
+    // scratch buffers (see `buildTransition`'s `prevGhostDrawn`), and through
+    // `ghostCullBuffer`, because that is the order those boxes were written
+    // in.
+    const prevGhostDrawn = new Map<number, Box>()
+    if (transition !== null) {
+      for (let g = 0; g < ghostDrawCount; g++) {
+        const ghost = transition.ghosts[ghostCullBuffer[g]!]
+        if (ghost !== undefined) prevGhostDrawn.set(ghost.source, boxAt(ghostDrawBoxes, g))
+      }
+    }
     const prevVisibleToSource = visibleToSource
     const prevParent = prunedParent
     const prevTransition = transition
@@ -1927,6 +1982,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
         prevParent,
         prevTransition,
         prevRenderBoxes,
+        prevGhostDrawn,
         boxes,
         visibleToSource,
         prunedParent,
@@ -2287,6 +2343,7 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
         }
         ghostCount = gcount
       }
+      ghostDrawCount = ghostCount
     }
     // --- end transition ---
 
@@ -2471,7 +2528,20 @@ export function createChartEngine(renderer: Renderer): ChartEngine {
       const boxes = new Float64Array(ghostCount * 4)
       const alpha = new Float32Array(ghostCount)
       for (let g = 0; g < ghostCount; g++) {
-        source[g] = transition.ghosts[g]!.source
+        // Through `ghostCullBuffer`, NOT `g` — and this is the whole bug the
+        // owner was seeing. `ghostDrawBoxes[g]` was written in CULLED order a
+        // few dozen lines above (`transition.ghosts[ghostCullBuffer[g]]`),
+        // because only the ghosts near the viewport are drawn and the
+        // quadtree returns them in its own order. Publishing
+        // `transition.ghosts[g].source` alongside it paired each source with
+        // whatever box happened to sit at the same offset in a differently
+        // ordered list, so the host's overlay — which pairs these two
+        // positionally to build its source -> box map — put cards on other
+        // nodes' geometry. On a fast expand interrupting a collapse that came
+        // out as every child drawn full-size on top of the parent, then flying
+        // down to its row: "when I click fast it starts from above the mouse,
+        // almost at the top border."
+        source[g] = transition.ghosts[ghostCullBuffer[g]!]!.source
         boxes[g * 4] = ghostDrawBoxes[g * 4]!
         boxes[g * 4 + 1] = ghostDrawBoxes[g * 4 + 1]!
         boxes[g * 4 + 2] = ghostDrawBoxes[g * 4 + 2]!

--- a/packages/engine/src/layout/tidy.test.ts
+++ b/packages/engine/src/layout/tidy.test.ts
@@ -218,6 +218,31 @@ describe('layout', () => {
     expect(a.x + a.w / 2).toBeCloseTo(childrenCentre, 6)
   })
 
+  it('leaves the same gap whichever of two siblings is the one with children', () => {
+    // The owner's report, from the status-card example: open one of the root's
+    // two branches and its closed sibling sits right beside it; open the OTHER
+    // one and the same closed sibling drifts a long way off. A node with a
+    // wide fan of children sits at their midpoint, and the separation walk
+    // could only ever push a subtree RIGHT — so when the wide branch was the
+    // left sibling the closed one was pushed tight against it, and when it was
+    // the right sibling its midpoint already cleared the closed one and
+    // nothing brought them back together. Two mirror-image trees have to lay
+    // out as mirror images.
+    const wide = (parent: string, prefix: string) =>
+      Array.from({ length: 5 }, (_, i) => ({ id: `${prefix}${i}`, parentId: parent }))
+    const base = [{ id: 'root' }, { id: 'p1', parentId: 'root' }, { id: 'p2', parentId: 'root' }]
+    const gapWith = (children: NodeData[]) => {
+      const tree = normalize([...base, ...children])
+      const { boxes } = layout(tree, uniformSizes(tree.count), OPTS)
+      const p1 = boxOf(tree, boxes, 'p1')
+      const p2 = boxOf(tree, boxes, 'p2')
+      return p2.x - (p1.x + p1.w)
+    }
+
+    expect(gapWith(wide('p1', 'a'))).toBe(OPTS.spacingX)
+    expect(gapWith(wide('p2', 'b'))).toBe(OPTS.spacingX)
+  })
+
   it('never overlaps siblings of differing widths', () => {
     const tree = normalize([{ id: 'a' }, { id: 'wide', parentId: 'a' }, { id: 'narrow', parentId: 'a' }])
     const sizes = uniformSizes(3)

--- a/packages/engine/src/layout/tidy.ts
+++ b/packages/engine/src/layout/tidy.ts
@@ -122,18 +122,33 @@ export function layout(tree: Tree, sizes: Float64Array, opts: LayoutOptions): La
     let cl = sibs[from + i]!
     let mscl = mod[cl]!
     let ih = iylTop
+    /**
+     * True once this subtree has been pushed right by anything: from then on
+     * it is hard against the contour to its left and there is nothing to
+     * close up. See `slack` below for the case where it never is.
+     */
+    let pushed = false
+    /**
+     * The LEAST slack any contour pair had — `dist` at its largest while
+     * still being negative, i.e. the closest the two contours ever come. Only
+     * meaningful while nothing has pushed.
+     */
+    let slack = -Infinity
 
     while (sr !== NONE && cl !== NONE) {
       while (ih !== NONE && bottom(sr) > iylLowY[ih]!) ih = iylNext[ih]!
 
       const dist = mssr + prelim[sr]! + width(sr) + opts.spacingX - (mscl + prelim[cl]!)
       if (dist > 0) {
+        pushed = true
         mscl += dist
         // Move the subtree and everything it drags with it.
         mod[sibs[from + i]!]! += dist
         msel[sibs[from + i]!]! += dist
         mser[sibs[from + i]!]! += dist
         distributeExtra(sibs, from, i, ih === NONE ? i - 1 : iylIndex[ih]!, dist)
+      } else if (!pushed && dist > slack) {
+        slack = dist
       }
 
       const sy = bottom(sr)
@@ -163,6 +178,35 @@ export function layout(tree: Tree, sizes: Float64Array, opts: LayoutOptions): La
     const self = sibs[from + i]!
     const left = sibs[from]!
     const prev = sibs[from + i - 1]!
+
+    // Nothing pushed this subtree, and every contour pair it was measured
+    // against had room to spare: close that gap by pulling it left, by
+    // exactly the least of it, so the tightest pair ends up `spacingX` apart.
+    //
+    // Without this the walk could only ever push, which made the layout
+    // asymmetric in a way the owner could see: a node with a wide fan of
+    // children sits at their midpoint, and if that midpoint already clears
+    // the sibling to its left, nothing brought the two back together. Open a
+    // branch and its closed sibling hugged it when the branch was on the
+    // LEFT (the sibling gets pushed right, tight against it) and drifted a
+    // hundred pixels away when it was on the RIGHT (nothing pushes, so the
+    // midpoint stands). Same tree, same two nodes, two different gaps
+    // depending on which one you happened to open.
+    //
+    // Safe by the same measurement that drives the pushes: `sr` follows the
+    // merged right contour of ALL the left siblings (that is what the
+    // threads are for), so `slack` is the minimum clearance against every
+    // one of them, and moving by it keeps the `spacingX` guarantee this
+    // function exists to provide. Only this subtree moves — deliberately no
+    // `distributeExtra`, which spreads a PUSH across the siblings in
+    // between: pulling those left as well would close them onto their own
+    // left neighbours, which nothing has measured.
+    if (!pushed && slack > -Infinity && slack < 0) {
+      mscl += slack
+      mod[self]! += slack
+      msel[self]! += slack
+      mser[self]! += slack
+    }
 
     if (sr === NONE && cl !== NONE) {
       // The left siblings ran out first: thread down to the current contour.

--- a/packages/engine/src/render/canvas2d.ts
+++ b/packages/engine/src/render/canvas2d.ts
@@ -2,7 +2,7 @@ import type { TextMeasurer } from '../text/measure.js'
 import type { DrawCallStats, Frame, Renderer, RenderSurface } from './renderer.js'
 import type { Theme } from './theme.js'
 import { easeInQuad, easeOutCubic } from '../viewport.js'
-import { bezierControls, edgeAnchors, hiddenStub } from './edge-geometry.js'
+import { bezierControls, edgeAnchors, hiddenStub, HIDDEN_DOT_PX, HIDDEN_STUB_PX } from './edge-geometry.js'
 import { computeNodeFills, inkOn } from './palette.js'
 import {
   isSectorVisible,
@@ -13,15 +13,10 @@ import {
   sectorPath,
 } from './sector.js'
 
-/**
- * The rectangular "more inside" mark, in SCREEN pixels: how far the stub
- * reaches out of the node, and the radius of the dot it ends in. Screen rather
- * than world so the mark is the same size at every zoom — it exists to be
- * noticed from far out, which is exactly where a world-scaled one would be
- * sub-pixel. Shared with `svg.ts`, whose export has to match the canvas.
- */
-export const HIDDEN_STUB_PX = 9
-export const HIDDEN_DOT_PX = 2.5
+// Re-exported from where the mark's GEOMETRY lives, so the numbers and the
+// function that places them cannot drift apart — and so the engine can read
+// them without importing a renderer backend. `svg.ts` imports them from here.
+export { HIDDEN_DOT_PX, HIDDEN_STUB_PX } from './edge-geometry.js'
 
 /**
  * Canvas2D backend.

--- a/packages/engine/src/render/edge-geometry.ts
+++ b/packages/engine/src/render/edge-geometry.ts
@@ -124,6 +124,17 @@ export function bezierControls(
 }
 
 /**
+ * The rectangular "more inside" mark, in SCREEN pixels: how far the stub
+ * reaches out of the node, and the radius of the dot it ends in. Screen rather
+ * than world so the mark is the same size at every zoom — it exists to be
+ * noticed from far out, which is exactly where a world-scaled one would be
+ * sub-pixel. Shared with `canvas2d.ts` and `svg.ts`, whose drawing has to
+ * match, and with the engine, whose reveal starts where this mark ends.
+ */
+export const HIDDEN_STUB_PX = 9
+export const HIDDEN_DOT_PX = 2.5
+
+/**
  * Where a "there is more inside this" mark hangs off a node, for the
  * rectangular layouts — the direction its first connector WOULD leave in, as a
  * unit vector, plus the point it would leave from.

--- a/packages/engine/src/worker/host.ts
+++ b/packages/engine/src/worker/host.ts
@@ -163,7 +163,27 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
   // slot — is what keeps `render()` correct regardless of that race.
   let sentCount = 0
   let framesReceived = 0
-  let pendingFrame: { target: number; resolve: (drawn: Uint32Array) => void } | null = null
+  /**
+   * Every `render()` still waiting for its own frame, not just the newest.
+   *
+   * It used to be a single slot, and a second `render()` arriving before the
+   * first had answered resolved the older one on the spot with an EMPTY
+   * `visible` array — "nothing is drawn" — purely to avoid orphaning its
+   * promise. That is a lie, and the caller believes it: the vanilla layer
+   * rebuilds its drawn-geometry mirror from exactly this array, so for that
+   * frame it thinks no node is on screen anywhere, and every question that
+   * mirror answers falls back to the SETTLED layout instead. A click landing
+   * in that window pins the camera on where a node will END UP rather than
+   * where it is — which, mid-transition, is off screen. Two renders in flight
+   * is not rare either: the frame loop awaits this promise, so any frame the
+   * worker is slow to answer lets the next `requestAnimationFrame` start
+   * another one, which is what a burst of rapid clicks produces.
+   *
+   * Waiting is the honest answer instead. Both callers get the next real
+   * frame; the older one is simply told about it a frame late, which is what
+   * it already was.
+   */
+  let pendingFrames: { target: number; resolve: (drawn: Uint32Array) => void }[] = []
   // Mirrors the in-process `engine.transitioning` for worker mode, updated
   // from each `frame` message's `transitioning` flag.
   let workerTransitioning = false
@@ -217,9 +237,15 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
           workerGhostSource = message.ghostSource
           workerGhostBoxes = message.ghostBoxes
           workerGhostAlpha = message.ghostAlpha
-          if (pendingFrame !== null && framesReceived >= pendingFrame.target) {
-            pendingFrame.resolve(message.visible)
-            pendingFrame = null
+          if (pendingFrames.length > 0) {
+            // Everything whose own frame has now arrived — usually one, more
+            // only when renders piled up (see `pendingFrames`). They all get
+            // THIS frame's answer, which is the newest truth there is.
+            const arrived = pendingFrames.filter((each) => framesReceived >= each.target)
+            if (arrived.length > 0) {
+              pendingFrames = pendingFrames.filter((each) => framesReceived < each.target)
+              for (const each of arrived) each.resolve(message.visible)
+            }
           }
         } else if (message.t === 'layout') {
           visibleToSource = message.visibleToSource
@@ -235,9 +261,10 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
           // after this promise settles, so one unresolved await is not a
           // dropped frame, it is the end of the animation loop. An empty
           // `visible` is the honest answer: nothing was drawn.
-          if (pendingFrame !== null) {
-            pendingFrame.resolve(new Uint32Array(0))
-            pendingFrame = null
+          if (pendingFrames.length > 0) {
+            const waiting = pendingFrames
+            pendingFrames = []
+            for (const each of waiting) each.resolve(new Uint32Array(0))
           }
         }
       }
@@ -366,13 +393,11 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
       // merely imprecise.
       if (engine !== null) return Promise.resolve(engine.render(now))
       return new Promise<Uint32Array>((resolve) => {
-        // Two renders in flight at once: the older one's frame is about to be
-        // counted against the newer one's target, so its promise would never
-        // settle. Hand it the same answer rather than orphaning it — a caller
-        // stuck on a promise that cannot resolve is the same permanent freeze
-        // as the error case above.
-        pendingFrame?.resolve(new Uint32Array(0))
-        pendingFrame = { target: sentCount + 1, resolve }
+        // Queued, not replaced: an older render still waiting keeps waiting
+        // and is answered by the next real frame alongside this one. See
+        // `pendingFrames` for what resolving it early with "nothing is drawn"
+        // did to the caller.
+        pendingFrames.push({ target: sentCount + 1, resolve })
         post({ t: 'render' }, [], now)
       })
     },
@@ -401,7 +426,12 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
       engine = null
       renderer = null
       quad = null
-      pendingFrame = null
+      // Let go of anything still waiting: the worker is gone, so its frame is
+      // never coming, and an unsettled promise here would hang the caller's
+      // frame loop for good.
+      const waiting = pendingFrames
+      pendingFrames = []
+      for (const each of waiting) each.resolve(new Uint32Array(0))
     },
 
     get boxes() {

--- a/packages/engine/src/worker/host.ts
+++ b/packages/engine/src/worker/host.ts
@@ -229,23 +229,40 @@ export function createChartHost(canvas: HTMLCanvasElement, theme: Theme, preferW
         const message = event.data
         if (message.t === 'frame') {
           framesReceived++
+          // Live state, read for scheduling decisions rather than paired with
+          // any particular set of boxes: always the newest.
           workerTransitioning = message.transitioning
           workerTransitionStartedAt = message.transitionStartedAt
           workerRingActive = message.ringActive
-          workerLastDrawnBoxes = message.lastDrawnBoxes
-          workerLastDrawnAlpha = message.lastDrawnAlpha
-          workerGhostSource = message.ghostSource
-          workerGhostBoxes = message.ghostBoxes
-          workerGhostAlpha = message.ghostAlpha
-          if (pendingFrames.length > 0) {
-            // Everything whose own frame has now arrived — usually one, more
-            // only when renders piled up (see `pendingFrames`). They all get
-            // THIS frame's answer, which is the newest truth there is.
-            const arrived = pendingFrames.filter((each) => framesReceived >= each.target)
-            if (arrived.length > 0) {
-              pendingFrames = pendingFrames.filter((each) => framesReceived < each.target)
-              for (const each of arrived) each.resolve(message.visible)
-            }
+          const arrived =
+            pendingFrames.length === 0 ? [] : pendingFrames.filter((each) => framesReceived >= each.target)
+          // The DRAWN GEOMETRY is published only with the frame a caller is
+          // actually handed, and never on its own.
+          //
+          // Every message the worker receives provokes a frame reply — a
+          // camera nudge, a toggle, a theme write — so between two renders
+          // this layer can see several frames the caller has not been given.
+          // Refreshing the mirror on each of them left `lastDrawnBoxes` from
+          // a NEWER frame than the `visible` array the caller was holding,
+          // and the vanilla layer pairs those two positionally to build its
+          // source -> box map. Mid-transition, when a collapse has just
+          // changed which nodes are drawn, that pairing silently handed a
+          // child its PARENT's box: the card was drawn full-size at the
+          // parent's own top-left corner and then flew down to its place —
+          // the owner's "when I click fast it starts from above the mouse,
+          // almost at the top border". Measured at 237 frames out of a dozen
+          // fast toggles. Publishing in lockstep with `resolve` below is what
+          // keeps the pair describing one frame.
+          if (arrived.length > 0) {
+            workerLastDrawnBoxes = message.lastDrawnBoxes
+            workerLastDrawnAlpha = message.lastDrawnAlpha
+            workerGhostSource = message.ghostSource
+            workerGhostBoxes = message.ghostBoxes
+            workerGhostAlpha = message.ghostAlpha
+            // Usually one, more only when renders piled up (see
+            // `pendingFrames`). They all get THIS frame's answer.
+            pendingFrames = pendingFrames.filter((each) => framesReceived < each.target)
+            for (const each of arrived) each.resolve(message.visible)
           }
         } else if (message.t === 'layout') {
           visibleToSource = message.visibleToSource

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -4,6 +4,42 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Klad Playground</title>
+    <meta
+      name="description"
+      content="Klad's interactive playground: one org chart drawn through every layout, card style and interaction the engine has — with the Vue, React or plain-DOM code for each beside it."
+    />
+
+    <!-- Rewritten with this build's `base` (see vite.config.ts), so it resolves
+         both at a site root and under `<docs base>/playground/`. -->
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="theme-color" content="#2563eb" />
+
+    <!-- Absolute, because a crawler reading a shared link has no page to
+         resolve a relative path against. The site is the docs site: same
+         origin, same og.png, one path down. -->
+    <link rel="canonical" href="https://klad.ozdemir.be/playground/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Klad" />
+    <meta property="og:title" content="Klad Playground" />
+    <meta
+      property="og:description"
+      content="Klad's interactive playground: one org chart drawn through every layout, card style and interaction the engine has — with the Vue, React or plain-DOM code for each beside it."
+    />
+    <meta property="og:url" content="https://klad.ozdemir.be/playground/" />
+    <meta property="og:image" content="https://klad.ozdemir.be/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Klad — a fast tree engine for very large hierarchies." />
+
+    <!-- `summary_large_image` renders the picture full width rather than as a
+         thumbnail beside the text. -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Klad Playground" />
+    <meta
+      name="twitter:description"
+      content="Klad's interactive playground: one org chart drawn through every layout, card style and interaction the engine has — with the Vue, React or plain-DOM code for each beside it."
+    />
+    <meta name="twitter:image" content="https://klad.ozdemir.be/og.png" />
   </head>
   <body>
     <div id="app"></div>

--- a/packages/playground/public/logo.svg
+++ b/packages/playground/public/logo.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Klad">
+  <!--
+    A copy of packages/docs/public/logo.svg, which is the original — keep the
+    two in step. It is duplicated rather than shared because the playground is
+    built as its own Vite app (twice: at a site root, and into the docs site
+    under `<docs base>/playground/`), and a `public/` file is the only asset
+    reference that survives both bases. Nothing here can reach into the docs
+    package's own `public/` at build time.
+
+    The same slabs as the hero image, reduced to three. Each node is drawn
+    twice: a darker copy offset down-and-right is its extruded side, the
+    gradient face sits on top. That is the whole trick, and it is what keeps
+    the mark related to the picture on the home page instead of being a
+    separate idea in the same colour.
+
+    Three nodes, not six: the thickness costs two pixels on every shape, and
+    at 16px there is only room for the volume or the detail, not both.
+  -->
+  <defs>
+    <linearGradient id="oc-face" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#3b82f6" />
+      <stop offset="1" stop-color="#60a5fa" />
+    </linearGradient>
+    <linearGradient id="oc-leaf" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#60a5fa" />
+      <stop offset="1" stop-color="#93c5fd" />
+    </linearGradient>
+  </defs>
+
+  <g fill="none" stroke="#94a3b8" stroke-width="3" stroke-linecap="round">
+    <path d="M24 18v5" />
+    <path d="M11 30v-7h26v7" />
+  </g>
+
+  <rect x="15" y="9" width="22" height="11" rx="3.5" fill="#1e40af" />
+  <rect x="13" y="6" width="22" height="11" rx="3.5" fill="url(#oc-face)" />
+
+  <rect x="6" y="32" width="15" height="10" rx="3" fill="#2563eb" />
+  <rect x="4" y="30" width="15" height="10" rx="3" fill="url(#oc-leaf)" />
+
+  <rect x="31" y="32" width="15" height="10" rx="3" fill="#2563eb" />
+  <rect x="29" y="30" width="15" height="10" rx="3" fill="url(#oc-leaf)" />
+</svg>

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1311,6 +1311,17 @@ restoreViewButton.onclick = () => {
   // where they were, and the flight is what tells them they went back rather
   // than that something jumped.
   currentApi?.setView(savedView, { animate: true })
+  // A saved view carries the isolated branch with it (see `ChartView`), so
+  // restoring one can isolate — or un-isolate — the chart just as the Isolate
+  // button does. The trail is this panel's own state, drawn from
+  // `getState().isolated`, and nothing recomputes it on its own: without this
+  // a view saved while isolated came back with the branch isolated and no way
+  // out of it drawn, which is precisely the "an isolated branch looks like a
+  // small chart rather than part of a big one" this panel exists to answer.
+  // `setView` applies the isolation synchronously, so the state is already
+  // right by the time this reads it.
+  branchSelect.value = ''
+  updateTrail()
 }
 
 /**


### PR DESCRIPTION
Everything here came out of one report: open or close a node and the camera slides away, worst on the root, until a dozen fast clicks have walked the chart off screen. Chasing it turned up several separate faults with the same symptom, then a second report about the reveal itself.

**Camera**

- A press panned from its very first move, including the pixel or two every real click travels — which told the vanilla layer "the user is panning" and dropped the anchor holding the toggled node. Panning now starts past the drag threshold.
- A release started a coast on velocity alone, so a click made by a moving hand glided ~100px. A fling now needs travel as well as speed.
- The anchor outranks the gesture for the half-second a branch is animating: a pan cannot move the toggled node, only zoom passes through. Dropping the anchor abandoned the node; re-pinning it accumulated every click's hand-drift.
- Taps resolve against what is on screen rather than the layout the chart is heading for, so a click mid-animation toggles the card it was aimed at.
- Worker path: two renders in flight resolved the older with an empty `visible`, and the anchor promotion could read a render that predates its own toggle. Both fixed; the hold now starts at the click rather than at the frame that promotes the anchor.

Measured on a dozen real clicks on the root over the worker path: 334px of drift before, under 2px after.

**Reveal**

- A child caught mid-reveal was carried at its finished size, and one caught mid-collapse at its parent's whole box — so a fast second click made cards jump to full size on top of the parent and fly down. Both are now carried at the box they were drawn at, read from the engine's own buffers (the ones handed to the host are transferred, and detached).
- Two alignment faults alongside: the published ghost source list paired sources with boxes written in a different order, and the worker host refreshed its geometry mirror on frames nobody awaited.
- Children grow out of the tip below their OWN parent at every depth, rather than out of the toggled node.
- The DOM overlay sized cards to their interpolated box, so a card reflowed its content instead of scaling — a full-size card pinned by its top-left while the box grew around it.
- Measured on the running playground: 240 frames out of ten fast toggles had a card on the wrong geometry; zero after.

**Layout**

- Siblings pack the same distance apart whichever one has children. The separation walk could only push right, so a closed sibling hugged an open branch on its left and stood 120px off one on its right.

**Also**

- The two animation phases overlap more, so an open or close reads as one move (450ms → 390ms).
- Playground: favicon, Open Graph/canonical metadata, and the isolation trail redrawn after a view is restored.